### PR TITLE
feat: update nix input to latest master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,15 +214,16 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1713862243,
-        "narHash": "sha256-mfJSQyO7je+/WSBmnl/LTGvqrzv3k1F0kEd7Wg+VXw4=",
-        "owner": "nixos",
+        "lastModified": 1714582044,
+        "narHash": "sha256-+I7oZyclF/qcQxJYCsKRfYDk5Yzo/Xug/XhI+bSrnx8=",
+        "owner": "hercules-ci",
         "repo": "nix",
-        "rev": "1cfc9da472f8dcfa7f521e544531d5e4daf2076c",
+        "rev": "38974360102e67aaf2434fd3f920e2cd1bb3fa75",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "hercules-ci",
+        "ref": "fix-eval-state-baseEnv-gc-root",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -92,9 +92,48 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -166,23 +205,24 @@
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts_2",
         "libgit2": "libgit2",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-regression": "nixpkgs-regression"
+        "nixpkgs-regression": "nixpkgs-regression",
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1711717219,
-        "narHash": "sha256-8nzsGORuUIkM91yKYz9f8/+eRMrLRHrqs+ExwLT01+8=",
-        "owner": "tweag",
+        "lastModified": 1713862243,
+        "narHash": "sha256-mfJSQyO7je+/WSBmnl/LTGvqrzv3k1F0kEd7Wg+VXw4=",
+        "owner": "nixos",
         "repo": "nix",
-        "rev": "926fbadcc30a4614b5f5a3d18a6f4096914f97da",
+        "rev": "1cfc9da472f8dcfa7f521e544531d5e4daf2076c",
         "type": "github"
       },
       "original": {
-        "owner": "tweag",
-        "ref": "nix-c-bindings",
+        "owner": "nixos",
         "repo": "nix",
         "type": "github"
       }
@@ -282,10 +322,42 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "nix"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": [
+          "nix"
+        ],
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713775815,
+        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -395,6 +467,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-    nix.url = "github:nixos/nix";
+    nix.url = "github:hercules-ci/nix/fix-eval-state-baseEnv-gc-root";
     nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-    nix.url = "github:tweag/nix/nix-c-bindings";
+    nix.url = "github:nixos/nix";
     nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,15 @@
               LIBCLANG_PATH
               BINDGEN_EXTRA_CLANG_ARGS
               ;
+            NIX_DEBUG_INFO_DIRS =
+              let
+                # TODO: add to Nixpkgs lib
+                getDebug = pkg:
+                  if pkg?debug then pkg.debug
+                  else if pkg?lib then pkg.lib
+                  else pkg;
+              in
+              "${getDebug config.packages.nix}/lib/debug";
             buildInputs = [
               config.packages.nix
             ];

--- a/rust/nix-store/src/store.rs
+++ b/rust/nix-store/src/store.rs
@@ -83,7 +83,7 @@ impl Store {
             raw::nix_store_get_uri(
                 self.context.ptr(),
                 self.inner.ptr(),
-                callback_get_vec_u8 as *mut std::ffi::c_void,
+                Some(callback_get_vec_u8),
                 &mut raw_buffer as *mut Vec<u8> as *mut std::ffi::c_void,
             )
         };


### PR DESCRIPTION
The Nix C bindings have now merged into master, with some small changes since these bindings were created. This PR updates the input, and adjusts it to the new API.

Cargo test does occasionally fail on my machine with a SEGV, but this issue is also present on current `main`.