### PR TITLE
Strip `nix_` prefix (& error handling fixes)

### DIFF
--- a/rust/nix-c-raw/build.rs
+++ b/rust/nix-c-raw/build.rs
@@ -2,6 +2,14 @@ use bindgen;
 use std::env;
 use std::path::PathBuf;
 
+#[derive(Debug)]
+struct StripNixPrefix {}
+impl bindgen::callbacks::ParseCallbacks for StripNixPrefix {
+    fn item_name(&self, name: &str) -> Option<String> {
+        name.strip_prefix("nix_").map(String::from)
+    }
+}
+
 fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=include/nix-c-raw.h");
@@ -14,6 +22,7 @@ fn main() {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(StripNixPrefix {}))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -52,8 +52,9 @@ impl EvalState {
                 store.raw_ptr(),
             )
         };
+        context.check_err()?;
         if eval_state.is_null() {
-            bail!("nix_state_create returned a null pointer");
+            panic!("nix_state_create returned a null pointer without an error");
         }
         Ok(EvalState {
             eval_state: NonNull::new(eval_state).unwrap(),
@@ -152,7 +153,7 @@ where
     if unsafe { raw::GC_thread_is_registered() } != 0 {
         return Ok(f());
     } else {
-        gc_register_my_thread().unwrap();
+        gc_register_my_thread()?;
         let r = f();
         unsafe {
             raw::GC_unregister_my_thread();

--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -169,7 +169,7 @@ pub fn gc_register_my_thread() -> Result<()> {
             return Ok(());
         }
         let mut sb: raw::GC_stack_base = raw::GC_stack_base {
-            mem_base: 0 as *mut _,
+            mem_base: null_mut(),
         };
         let r = raw::GC_get_stack_base(&mut sb);
         if r as u32 != raw::GC_SUCCESS {

--- a/rust/nix-expr/src/value.rs
+++ b/rust/nix-expr/src/value.rs
@@ -58,7 +58,7 @@ impl Drop for Value {
     fn drop(&mut self) {
         let context = Context::new();
         unsafe {
-            raw::nix_gc_decref(context.ptr(), self.inner.as_ptr());
+            raw::gc_decref(context.ptr(), self.inner.as_ptr());
         }
         // ignore error from context, because drop should not panic
     }
@@ -66,7 +66,7 @@ impl Drop for Value {
 impl Clone for Value {
     fn clone(&self) -> Self {
         let context = Context::new();
-        unsafe { raw::nix_gc_incref(context.ptr(), self.inner.as_ptr()) };
+        unsafe { raw::gc_incref(context.ptr(), self.inner.as_ptr()) };
         context.check_err().unwrap();
         Value { inner: self.inner }
     }

--- a/rust/nix-store/src/store.rs
+++ b/rust/nix-store/src/store.rs
@@ -12,7 +12,7 @@ lazy_static! {
     static ref INIT: Result<()> = {
         unsafe {
             let context: Context = Context::new();
-            raw::nix_libstore_init(context.ptr());
+            raw::libstore_init(context.ptr());
             context.check_err()
         }
     };
@@ -29,7 +29,7 @@ impl StoreRef {
 impl Drop for StoreRef {
     fn drop(&mut self) {
         unsafe {
-            raw::nix_store_free(self.inner.as_ptr());
+            raw::store_free(self.inner.as_ptr());
         }
     }
 }
@@ -54,7 +54,7 @@ impl Store {
 
         let uri_ptr = CString::new(url)?;
         let store = unsafe {
-            raw::nix_store_open(
+            raw::store_open(
                 context.ptr(),
                 uri_ptr.as_ptr(),
                 null_mut::<*mut *const i8>(),
@@ -80,7 +80,7 @@ impl Store {
     pub fn get_uri(&self) -> Result<String> {
         let mut raw_buffer: Vec<u8> = Vec::new();
         unsafe {
-            raw::nix_store_get_uri(
+            raw::store_get_uri(
                 self.context.ptr(),
                 self.inner.ptr(),
                 Some(callback_get_vec_u8),

--- a/rust/nix-store/src/store.rs
+++ b/rust/nix-store/src/store.rs
@@ -62,7 +62,7 @@ impl Store {
         };
         context.check_err()?;
         if store.is_null() {
-            bail!("nix_c_store_open returned a null pointer");
+            panic!("nix_c_store_open returned a null pointer without an error");
         }
         let store = Store {
             inner: StoreRef {

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -11,6 +11,8 @@ impl Context {
     pub fn new() -> Self {
         let ctx = unsafe { raw::c_context_create() };
         if ctx.is_null() {
+            // We've failed to allocate a (relatively small) Context struct.
+            // We're almost certainly going to crash anyways.
             panic!("nix_c_context_create returned a null pointer");
         }
         let ctx = Context {
@@ -24,7 +26,7 @@ impl Context {
     pub fn check_err(&self) -> Result<()> {
         let err = unsafe { raw::err_code(self.inner.as_ptr()) };
         if err != raw::NIX_OK.try_into().unwrap() {
-            // msgp is a borrowed pointer, so we don't need to free it
+            // msgp is a borrowed pointer (pointing into the context), so we don't need to free it
             let msgp = unsafe { raw::err_msg(null_mut(), self.inner.as_ptr(), null_mut()) };
             // Turn the i8 pointer into a Rust string by copying
             let msg: &str = unsafe { core::ffi::CStr::from_ptr(msgp).to_str()? };

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -4,12 +4,12 @@ use std::ptr::null_mut;
 use std::ptr::NonNull;
 
 pub struct Context {
-    inner: NonNull<raw::nix_c_context>,
+    inner: NonNull<raw::c_context>,
 }
 
 impl Context {
     pub fn new() -> Self {
-        let ctx = unsafe { raw::nix_c_context_create() };
+        let ctx = unsafe { raw::c_context_create() };
         if ctx.is_null() {
             panic!("nix_c_context_create returned a null pointer");
         }
@@ -18,14 +18,14 @@ impl Context {
         };
         ctx
     }
-    pub fn ptr(&self) -> *mut raw::nix_c_context {
+    pub fn ptr(&self) -> *mut raw::c_context {
         self.inner.as_ptr()
     }
     pub fn check_err(&self) -> Result<()> {
-        let err = unsafe { raw::nix_err_code(self.inner.as_ptr()) };
+        let err = unsafe { raw::err_code(self.inner.as_ptr()) };
         if err != raw::NIX_OK.try_into().unwrap() {
             // msgp is a borrowed pointer, so we don't need to free it
-            let msgp = unsafe { raw::nix_err_msg(null_mut(), self.inner.as_ptr(), null_mut()) };
+            let msgp = unsafe { raw::err_msg(null_mut(), self.inner.as_ptr(), null_mut()) };
             // Turn the i8 pointer into a Rust string by copying
             let msg: &str = unsafe { core::ffi::CStr::from_ptr(msgp).to_str()? };
             bail!("{}", msg);
@@ -37,7 +37,7 @@ impl Context {
 impl Drop for Context {
     fn drop(&mut self) {
         unsafe {
-            raw::nix_c_context_free(self.inner.as_ptr());
+            raw::c_context_free(self.inner.as_ptr());
         }
     }
 }

--- a/rust/nix-util/src/string_return.rs
+++ b/rust/nix-util/src/string_return.rs
@@ -1,6 +1,8 @@
 /// Callback for nix_store_get_uri and other functions that return a string.
 ///
 /// This function is used by the other nix_* crates, and you should never need to call it yourself.
+///
+/// Some functions in the nix library "return" strings without giving you ownership over them, by letting you pass a callback function that gets to look at that string. This callback simply turns that string pointer into an owned rust String.
 pub unsafe extern "C" fn callback_get_vec_u8(
     start: *const ::std::os::raw::c_char,
     n: std::os::raw::c_uint,

--- a/rust/nix-util/src/string_return.rs
+++ b/rust/nix-util/src/string_return.rs
@@ -20,7 +20,7 @@ mod tests {
     use nix_c_raw as raw;
 
     /// Typecheck the function signature against the generated bindings in nix_c_raw.
-    static _CALLBACK_GET_VEC_U8: raw::nix_get_string_callback = Some(callback_get_vec_u8);
+    static _CALLBACK_GET_VEC_U8: raw::get_string_callback = Some(callback_get_vec_u8);
 
     #[test]
     fn test_callback_get_vec_u8_empty() {


### PR DESCRIPTION
@roberth and I discussed some changes. Mostly I made issues for them, but a couple of them I just hashed out myself.

The main change is to have bindgen strip out the `nix_` prefix on all the c api calls. With this place in change I think we might want to rename the `raw::` imports to `nix::`. I assume you didn't have that to begin with because `nix::nix_foo()` would have looked ugly. I wasn't sure though so I didn't make that change in this PR.

I also fixed and commented some of the error handling.