### PR TITLE
Apply

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -875,6 +875,8 @@ mod tests {
             let v = es.new_value_apply(&f, &a).unwrap();
             assert!(es.value_is_thunk(&v));
             es.force(&v).unwrap();
+            let t = es.value_type(&v).unwrap();
+            assert!(t == ValueType::Int);
             let i = es.require_int(&v).unwrap();
             assert!(i == 3);
         })


### PR DESCRIPTION
This takes `EvalState::apply` taken from my prototype branch, renames it according to #37 and then merges the remaining significant difference into it.
This implementation takes references instead of by-value `Value`s, which is slightly more efficient, because it doesn't have to `incref` and `decref`.
Closes #37