### PR TITLE
Use `///` doc comments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           # without nightly, and it might do too much.
           pre-commit.settings.hooks.rust-doc-comments = {
             enable = true;
-            files = ".*.rs$";
+            files = "\\.rs$";
             entry = "${pkgs.writeScript "rust-doc-comments" ''
               #!${pkgs.runtimeShell}
               set -uxo pipefail

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,26 @@
           pre-commit.settings.hooks.rustfmt.enable = true;
           pre-commit.settings.settings.rust.cargoManifestPath = "./rust/Cargo.toml";
 
+          # Check that we're using ///-style doc comments in Rust code.
+          #
+          # Unfortunately, rustfmt won't do this for us yet - at least not
+          # without nightly, and it might do too much.
+          pre-commit.settings.hooks.rust-doc-comments = {
+            enable = true;
+            files = ".*.rs$";
+            entry = "${pkgs.writeScript "rust-doc-comments" ''
+              #!${pkgs.runtimeShell}
+              set -uxo pipefail
+              grep -n -C3 --color=always -F '/**' "$@"
+              r=$?
+              set -e
+              if [ $r -eq 0 ]; then
+                echo "Please replace /**-style comments by /// style comments in Rust code."
+                exit 1
+              fi
+            ''}";
+          };
+
           devShells.default = pkgs.mkShell {
             name = "nixops4-devshell";
             strictDeps = true;

--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -107,7 +107,7 @@ impl EvalState {
         self.context.check_err()?;
         Ok(value)
     }
-    /** Try turn any Value into a Value that isn't a Thunk. */
+    /// Try turn any Value into a Value that isn't a Thunk.
     pub fn force(&self, v: &Value) -> Result<()> {
         unsafe {
             raw::value_force(self.context.ptr(), self.raw_ptr(), v.raw_ptr());
@@ -340,7 +340,7 @@ pub fn gc_now() {
     }
 }
 
-/** Run a function while making sure that the current thread is registered with the GC. */
+/// Run a function while making sure that the current thread is registered with the GC.
 pub fn gc_registering_current_thread<F, R>(f: F) -> Result<R>
 where
     F: FnOnce() -> R,

--- a/rust/nix-expr/src/value.rs
+++ b/rust/nix-expr/src/value.rs
@@ -6,7 +6,7 @@ use std::ptr::{null_mut, NonNull};
 
 pub type Int = i64;
 
-/** The type of a value (or thunk) */
+/// The type of a value (or thunk)
 #[derive(Eq, PartialEq, Debug)]
 pub enum ValueType {
     AttrSet,

--- a/rust/nix-store/src/path.rs
+++ b/rust/nix-store/src/path.rs
@@ -9,20 +9,16 @@ pub struct StorePath {
     raw: *mut raw::StorePath,
 }
 impl StorePath {
-    /**
-     * This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
-     *
-     * Construct a new `StorePath` by first cloning the C store path.
-     * This does not take ownership of the C store path, so it should be a borrowed value, or you should free it.
-     */
+    /// This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
+    ///
+    /// Construct a new `StorePath` by first cloning the C store path.
+    /// This does not take ownership of the C store path, so it should be a borrowed value, or you should free it.
     pub fn new_raw_clone(raw: *const raw::StorePath) -> Self {
         Self::new_raw(unsafe { raw::store_path_clone(raw as *mut raw::StorePath) })
     }
-    /**
-     * This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
-     *
-     * Takes ownership of a C `nix_store_path`. It will be freed when the `StorePath` is dropped.
-     */
+    /// This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
+    ///
+    /// Takes ownership of a C `nix_store_path`. It will be freed when the `StorePath` is dropped.
     pub fn new_raw(raw: *mut raw::StorePath) -> Self {
         StorePath { raw }
     }


### PR DESCRIPTION
This appears to be the more idiomatic choice.