### PR TITLE
doc: `EvalState::eval_from_string`

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -88,6 +88,25 @@ impl EvalState {
     pub fn store(&self) -> &Store {
         &self.store
     }
+    /// Parses and evaluates a Nix expression `expr`.
+    ///
+    /// Expressions can contain relative paths such as `./.` that are resolved relative to the given `path`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nix_expr::eval_state::EvalState;
+    /// use nix_store::store::Store;
+    /// use nix_expr::value::Value;
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let es = EvalState::new(Store::open("auto")?, [])?;
+    /// let v: Value = es.eval_from_string("42", ".")?;
+    /// assert_eq!(es.require_int(&v)?, 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "nix_expr_eval_from_string")]
     pub fn eval_from_string(&self, expr: &str, path: &str) -> Result<Value> {
         let expr_ptr =
             CString::new(expr).with_context(|| "eval_from_string: expr contains null byte")?;


### PR DESCRIPTION
added a documentation comment to `EvalState::eval_from_string` base on [`nix_expr_eval_from_string`](https://hydra.nixos.org/build/261507418/download/1/html/group__libexpr.html#ga8c278f29be2c68409dcc0d280f489b8d)'s documentation, an example, and a `#[doc(alias)]` attribute as recommended [in the rustdoc book](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#ffi-example). it renders as follows.

![image](https://github.com/nixops4/nixops4/assets/30812734/cca2eafd-5cc7-4dee-bb22-70a76cc9b76d)

i wonder if it makes more sense to write these documentation comments manually or try and automatize adding them based on the nix api's documentation. and i wonder if it makes sense to add these documentation comments already or if this library is still in too much of an experimental stage to justify the effort.