### PR TITLE
remove `Thunk` from `ValueType` and introduce `ValueTypeOrThunk`

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -119,7 +119,7 @@ impl EvalState {
         self.context.check_err().unwrap();
         ValueTypeOrThunk::from_raw(r)
     }
-    pub fn value_type_forced(&self, value: &Value) -> Result<ValueType> {
+    pub fn value_type(&self, value: &Value) -> Result<ValueType> {
         match self.value_type_unforced(value) {
             ValueTypeOrThunk::ValueType(a) => Ok(a),
             ValueTypeOrThunk::Thunk => {
@@ -134,7 +134,7 @@ impl EvalState {
         }
     }
     pub fn require_int(&self, v: &Value) -> Result<Int> {
-        let t = self.value_type_forced(v).unwrap();
+        let t = self.value_type(v).unwrap();
         if t != ValueType::Int {
             bail!("expected an int, but got a {:?}", t);
         }
@@ -144,7 +144,7 @@ impl EvalState {
     /// Evaluate, and require that the value is an attrset.
     /// Returns a list of the keys in the attrset.
     pub fn require_attrs_names(&self, v: &Value) -> Result<Vec<String>> {
-        let t = self.value_type_forced(v)?;
+        let t = self.value_type(v)?;
         if t != ValueType::AttrSet {
             bail!("expected an attrset, but got a {:?}", t);
         }
@@ -183,7 +183,7 @@ impl EvalState {
 
     /// Evaluate, require that the value is an attrset, and select an attribute by name.
     pub fn require_attrs_select_opt(&self, v: &Value, attr_name: &str) -> Result<Option<Value>> {
-        let t = self.value_type_forced(v)?;
+        let t = self.value_type(v)?;
         if t != ValueType::AttrSet {
             bail!("expected an attrset, but got a {:?}", t);
         }
@@ -245,7 +245,7 @@ impl EvalState {
     }
     /// NOTE: this will be replaced by two methods, one that also returns the context, and one that checks that the context is empty
     pub fn require_string(&self, value: &Value) -> Result<String> {
-        let t = self.value_type_forced(value)?;
+        let t = self.value_type(value)?;
         if t != ValueType::String {
             bail!("expected a string, but got a {:?}", t);
         }
@@ -256,7 +256,7 @@ impl EvalState {
         value: &Value,
         is_import_from_derivation: bool,
     ) -> Result<RealisedString> {
-        let t = self.value_type_forced(value)?;
+        let t = self.value_type(value)?;
         if t != ValueType::String {
             bail!("expected a string, but got a {:?}", t);
         }

--- a/rust/nix-expr/src/value.rs
+++ b/rust/nix-expr/src/value.rs
@@ -19,26 +19,31 @@ pub enum ValueType {
     Null,
     Path,
     String,
-    Thunk,
     Unknown,
 }
 
-impl ValueType {
-    pub(crate) fn from_raw(raw: raw::ValueType) -> ValueType {
+#[derive(Eq, PartialEq, Debug)]
+pub enum ValueTypeOrThunk {
+    ValueType(ValueType),
+    Thunk,
+}
+
+impl ValueTypeOrThunk {
+    pub(crate) fn from_raw(raw: raw::ValueType) -> ValueTypeOrThunk {
         match raw {
-            raw::ValueType_NIX_TYPE_ATTRS => ValueType::AttrSet,
-            raw::ValueType_NIX_TYPE_BOOL => ValueType::Bool,
-            raw::ValueType_NIX_TYPE_EXTERNAL => ValueType::External,
-            raw::ValueType_NIX_TYPE_FLOAT => ValueType::Float,
-            raw::ValueType_NIX_TYPE_FUNCTION => ValueType::Function,
-            raw::ValueType_NIX_TYPE_INT => ValueType::Int,
-            raw::ValueType_NIX_TYPE_LIST => ValueType::List,
-            raw::ValueType_NIX_TYPE_NULL => ValueType::Null,
-            raw::ValueType_NIX_TYPE_PATH => ValueType::Path,
-            raw::ValueType_NIX_TYPE_STRING => ValueType::String,
-            raw::ValueType_NIX_TYPE_THUNK => ValueType::Thunk,
+            raw::ValueType_NIX_TYPE_ATTRS => ValueTypeOrThunk::ValueType(ValueType::AttrSet),
+            raw::ValueType_NIX_TYPE_BOOL => ValueTypeOrThunk::ValueType(ValueType::Bool),
+            raw::ValueType_NIX_TYPE_EXTERNAL => ValueTypeOrThunk::ValueType(ValueType::External),
+            raw::ValueType_NIX_TYPE_FLOAT => ValueTypeOrThunk::ValueType(ValueType::Float),
+            raw::ValueType_NIX_TYPE_FUNCTION => ValueTypeOrThunk::ValueType(ValueType::Function),
+            raw::ValueType_NIX_TYPE_INT => ValueTypeOrThunk::ValueType(ValueType::Int),
+            raw::ValueType_NIX_TYPE_LIST => ValueTypeOrThunk::ValueType(ValueType::List),
+            raw::ValueType_NIX_TYPE_NULL => ValueTypeOrThunk::ValueType(ValueType::Null),
+            raw::ValueType_NIX_TYPE_PATH => ValueTypeOrThunk::ValueType(ValueType::Path),
+            raw::ValueType_NIX_TYPE_STRING => ValueTypeOrThunk::ValueType(ValueType::String),
+            raw::ValueType_NIX_TYPE_THUNK => ValueTypeOrThunk::Thunk,
             // This would happen if a new type of value is added in Nix.
-            _ => ValueType::Unknown,
+            _ => ValueTypeOrThunk::ValueType(ValueType::Unknown),
         }
     }
 }

--- a/rust/nix-expr/src/value.rs
+++ b/rust/nix-expr/src/value.rs
@@ -22,28 +22,29 @@ pub enum ValueType {
     Unknown,
 }
 
-#[derive(Eq, PartialEq, Debug)]
-pub enum ValueTypeOrThunk {
-    ValueType(ValueType),
-    Thunk,
-}
-
-impl ValueTypeOrThunk {
-    pub(crate) fn from_raw(raw: raw::ValueType) -> ValueTypeOrThunk {
+impl ValueType {
+    /// Convert a raw value type to a `ValueType`.
+    ///
+    /// Return `None` if the Value is still a thunk (i.e. not yet evaluated).
+    ///
+    /// Return `Some(ValueType::Unknown)` if the value type is not recognized.
+    pub(crate) fn from_raw(raw: raw::ValueType) -> Option<ValueType> {
         match raw {
-            raw::ValueType_NIX_TYPE_ATTRS => ValueTypeOrThunk::ValueType(ValueType::AttrSet),
-            raw::ValueType_NIX_TYPE_BOOL => ValueTypeOrThunk::ValueType(ValueType::Bool),
-            raw::ValueType_NIX_TYPE_EXTERNAL => ValueTypeOrThunk::ValueType(ValueType::External),
-            raw::ValueType_NIX_TYPE_FLOAT => ValueTypeOrThunk::ValueType(ValueType::Float),
-            raw::ValueType_NIX_TYPE_FUNCTION => ValueTypeOrThunk::ValueType(ValueType::Function),
-            raw::ValueType_NIX_TYPE_INT => ValueTypeOrThunk::ValueType(ValueType::Int),
-            raw::ValueType_NIX_TYPE_LIST => ValueTypeOrThunk::ValueType(ValueType::List),
-            raw::ValueType_NIX_TYPE_NULL => ValueTypeOrThunk::ValueType(ValueType::Null),
-            raw::ValueType_NIX_TYPE_PATH => ValueTypeOrThunk::ValueType(ValueType::Path),
-            raw::ValueType_NIX_TYPE_STRING => ValueTypeOrThunk::ValueType(ValueType::String),
-            raw::ValueType_NIX_TYPE_THUNK => ValueTypeOrThunk::Thunk,
+            raw::ValueType_NIX_TYPE_ATTRS => Some(ValueType::AttrSet),
+            raw::ValueType_NIX_TYPE_BOOL => Some(ValueType::Bool),
+            raw::ValueType_NIX_TYPE_EXTERNAL => Some(ValueType::External),
+            raw::ValueType_NIX_TYPE_FLOAT => Some(ValueType::Float),
+            raw::ValueType_NIX_TYPE_FUNCTION => Some(ValueType::Function),
+            raw::ValueType_NIX_TYPE_INT => Some(ValueType::Int),
+            raw::ValueType_NIX_TYPE_LIST => Some(ValueType::List),
+            raw::ValueType_NIX_TYPE_NULL => Some(ValueType::Null),
+            raw::ValueType_NIX_TYPE_PATH => Some(ValueType::Path),
+            raw::ValueType_NIX_TYPE_STRING => Some(ValueType::String),
+
+            raw::ValueType_NIX_TYPE_THUNK => None,
+
             // This would happen if a new type of value is added in Nix.
-            _ => ValueTypeOrThunk::ValueType(ValueType::Unknown),
+            _ => Some(ValueType::Unknown),
         }
     }
 }


### PR DESCRIPTION
- https://github.com/nixops4/nixops4/pull/42/commits/47a89bc8b6b212e11f977fb45411ddd96b616aa0
  - removes `Thunk` from `ValueType`
  - introduces `enum ValueTypeOrThunk {ValueType(ValueType), Thunk}`
  - turns `value_type` into `value_type_forced([...]) -> Result<ValueType>`
  - turns `value_is_thunk` into `value_type_unforced([...]) -> ValueTypeOrThunk`
- https://github.com/nixops4/nixops4/pull/42/commits/6efdc0f69c8c1f105303fbb36713b18ca74e6653 adjusts `ValueType` use sites

this is a proposal for how to address https://github.com/nixops4/nixops4/issues/30.

**to do before merge**
- [x] adjust `value_type_forced` use sites
- [x] turn `ValueTypeOrThunk` into `Option<ValueType>`

Closes #30