### PR TITLE
check_call!() macro to use () not []

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -225,12 +225,12 @@ impl EvalState {
         let attr_name = CString::new(attr_name)
             .with_context(|| "require_attrs_select_opt: attrName contains null byte")?;
         let v2 = unsafe {
-            check_call_opt_key!(raw::get_attr_byname[
+            check_call_opt_key!(raw::get_attr_byname(
                 &mut self.context,
                 v.raw_ptr(),
                 self.eval_state.as_ptr(),
                 attr_name.as_ptr()
-            ])
+            ))
         }?;
         Ok(v2.map(Value::new))
     }

--- a/rust/nix-expr/src/value.rs
+++ b/rust/nix-expr/src/value.rs
@@ -77,7 +77,7 @@ impl Clone for Value {
         //       this is very unlikely to error, and it is not recoverable
         //       Maybe try without, and try again with context to report details?
         unsafe {
-            check_call!(raw::gc_incref[&mut Context::new(), self.inner.as_ptr()]).unwrap();
+            check_call!(raw::gc_incref(&mut Context::new(), self.inner.as_ptr())).unwrap();
         }
         // can't return an error here, but we don't want to ignore the error either as it means we could use-after-free
         Value { inner: self.inner }

--- a/rust/nix-store/src/store.rs
+++ b/rust/nix-store/src/store.rs
@@ -11,7 +11,7 @@ use std::ptr::NonNull;
 /* TODO make Nix itself thread safe */
 lazy_static! {
     static ref INIT: Result<()> = unsafe {
-        check_call!(raw::libstore_init[&mut Context::new()])?;
+        check_call!(raw::libstore_init(&mut Context::new()))?;
         Ok(())
     };
 }
@@ -74,7 +74,11 @@ impl Store {
             .collect();
 
         let store = unsafe {
-            check_call!(raw::store_open[&mut context, uri_ptr.as_ptr(), params.as_mut_ptr()])
+            check_call!(raw::store_open(
+                &mut context,
+                uri_ptr.as_ptr(),
+                params.as_mut_ptr()
+            ))
         }?;
         if store.is_null() {
             panic!("nix_c_store_open returned a null pointer without an error");
@@ -95,7 +99,12 @@ impl Store {
     pub fn get_uri(&mut self) -> Result<String> {
         let mut r = result_string_init!();
         unsafe {
-            check_call!(raw::store_get_uri[&mut self.context, self.inner.ptr(), Some(callback_get_result_string), callback_get_result_string_data(&mut r)])
+            check_call!(raw::store_get_uri(
+                &mut self.context,
+                self.inner.ptr(),
+                Some(callback_get_result_string),
+                callback_get_result_string_data(&mut r)
+            ))
         }?;
         r
     }

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -85,10 +85,10 @@ impl Drop for Context {
 
 #[macro_export]
 macro_rules! check_call {
-    ($f:path[$ctx:expr $(, $arg:expr)*]) => {
+    ($($f:ident)::+($ctx:expr $(, $arg:expr)*)) => {
         {
             let ctx : &mut $crate::context::Context = $ctx;
-            let ret = $f(ctx.ptr() $(, $arg)*);
+            let ret = $($f)::*(ctx.ptr() $(, $arg)*);
             match ctx.check_err() {
                 Ok(_) => Ok(ret),
                 Err(e) => {
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn check_call_dynamic_context() {
-        let r = check_call!(set_dummy_err[&mut Context::new()]);
+        let r = check_call!(set_dummy_err(&mut Context::new()));
         assert!(r.is_err());
         assert_eq!(r.unwrap_err().to_string(), "dummy error message");
     }

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -105,10 +105,10 @@ pub use check_call;
 // TODO: Generalize this macro to work with any error code or any error handling logic
 #[macro_export]
 macro_rules! check_call_opt_key {
-    ($f:path[$ctx:expr, $($arg:expr),*]) => {
+    ($($f:ident)::+($ctx:expr, $($arg:expr),*)) => {
         {
             let ctx : &mut $crate::context::Context = $ctx;
-            let ret = $f(ctx.ptr(), $($arg,)*);
+            let ret = $($f)::*(ctx.ptr(), $($arg,)*);
             if unsafe { raw::err_code(ctx.ptr()) == raw::NIX_ERR_KEY } {
                 ctx.clear();
                 return Ok(None);

--- a/rust/nix-util/src/settings.rs
+++ b/rust/nix-util/src/settings.rs
@@ -11,7 +11,7 @@ pub fn set(key: &str, value: &str) -> Result<()> {
     let key = std::ffi::CString::new(key)?;
     let value = std::ffi::CString::new(value)?;
     unsafe {
-        check_call!(raw::setting_set[&mut ctx, key.as_ptr(), value.as_ptr()])?;
+        check_call!(raw::setting_set(&mut ctx, key.as_ptr(), value.as_ptr()))?;
     }
     Ok(())
 }
@@ -21,7 +21,12 @@ pub fn get(key: &str) -> Result<String> {
     let key = std::ffi::CString::new(key)?;
     let mut r: Result<String> = result_string_init!();
     unsafe {
-        check_call!(raw::setting_get[&mut ctx, key.as_ptr(), Some(callback_get_result_string), callback_get_result_string_data(&mut r)])?;
+        check_call!(raw::setting_get(
+            &mut ctx,
+            key.as_ptr(),
+            Some(callback_get_result_string),
+            callback_get_result_string_data(&mut r)
+        ))?;
     }
     r
 }
@@ -36,7 +41,7 @@ mod tests {
     fn setup() {
         let mut ctx = context::Context::new();
         unsafe {
-            check_call!(raw::libstore_init[&mut ctx]).unwrap();
+            check_call!(raw::libstore_init(&mut ctx)).unwrap();
         }
     }
 


### PR DESCRIPTION
I could have sworn this was the first thing I tried to get `()` working in the macro, but clearly not XD.