### PR TITLE
Site

### DIFF
--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,5 +1,8 @@
-{ inputs, ... }: {
-  imports = [ inputs.pre-commit-hooks-nix.flakeModule ];
+{ lib, inputs, withSystem, ... }: {
+  imports = [
+    inputs.pre-commit-hooks-nix.flakeModule
+    inputs.hercules-ci-effects.flakeModule
+  ];
   perSystem = { config, pkgs, ... }: {
 
     pre-commit.settings.hooks.nixpkgs-fmt.enable = true;
@@ -54,6 +57,7 @@
         pkgs.clang-tools # clangd
         pkgs.valgrind
         pkgs.gdb
+        pkgs.hci
         # TODO: set up cargo-valgrind in shell and build
         #       currently both this and `cargo install cargo-valgrind`
         #       produce a binary that says ENOENT.
@@ -67,7 +71,8 @@
       NIX_PATH = "nixpkgs=${inputs.nixpkgs}";
     };
   };
-  flake = {
-    herculesCI.ciSystems = [ "x86_64-linux" ];
+  herculesCI = hci@{ config, ... }: {
+    ciSystems = [ "x86_64-linux" ];
   };
+  flake = { };
 }

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,0 +1,73 @@
+{ inputs, ... }: {
+  imports = [ inputs.pre-commit-hooks-nix.flakeModule ];
+  perSystem = { config, pkgs, ... }: {
+
+    pre-commit.settings.hooks.nixpkgs-fmt.enable = true;
+    pre-commit.settings.hooks.rustfmt.enable = true;
+    pre-commit.settings.settings.rust.cargoManifestPath = "./rust/Cargo.toml";
+
+    # Check that we're using ///-style doc comments in Rust code.
+    #
+    # Unfortunately, rustfmt won't do this for us yet - at least not
+    # without nightly, and it might do too much.
+    pre-commit.settings.hooks.rust-doc-comments = {
+      enable = true;
+      files = "\\.rs$";
+      entry = "${pkgs.writeScript "rust-doc-comments" ''
+        #!${pkgs.runtimeShell}
+        set -uxo pipefail
+        grep -n -C3 --color=always -F '/**' "$@"
+        r=$?
+        set -e
+        if [ $r -eq 0 ]; then
+          echo "Please replace /**-style comments by /// style comments in Rust code."
+          exit 1
+        fi
+      ''}";
+    };
+
+    devShells.default = pkgs.mkShell {
+      name = "nixops4-devshell";
+      strictDeps = true;
+      inputsFrom = [ config.nci.outputs.nixops4-project.devShell ];
+      inherit (config.nci.outputs.nixops4-project.devShell.env)
+        LIBCLANG_PATH
+        BINDGEN_EXTRA_CLANG_ARGS
+        ;
+      NIX_DEBUG_INFO_DIRS =
+        let
+          # TODO: add to Nixpkgs lib
+          getDebug = pkg:
+            if pkg?debug then pkg.debug
+            else if pkg?lib then pkg.lib
+            else pkg;
+        in
+        "${getDebug config.packages.nix}/lib/debug";
+      buildInputs = [
+        config.packages.nix
+      ];
+      nativeBuildInputs = [
+        pkgs.rust-analyzer
+        pkgs.nixpkgs-fmt
+        pkgs.rustfmt
+        pkgs.pkg-config
+        pkgs.clang-tools # clangd
+        pkgs.valgrind
+        pkgs.gdb
+        # TODO: set up cargo-valgrind in shell and build
+        #       currently both this and `cargo install cargo-valgrind`
+        #       produce a binary that says ENOENT.
+        # pkgs.cargo-valgrind
+      ];
+      shellHook = ''
+        ${config.pre-commit.installationScript}
+        echo 1>&2 "Welcome to the development shell!"
+      '';
+      # rust-analyzer needs a NIX_PATH for some reason
+      NIX_PATH = "nixpkgs=${inputs.nixpkgs}";
+    };
+  };
+  flake = {
+    herculesCI.ciSystems = [ "x86_64-linux" ];
+  };
+}

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1719226092,
-        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "lastModified": 1724947644,
+        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
         "type": "github"
       },
       "original": {

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -16,6 +16,26 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -34,6 +54,41 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1719226092,
+        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713714899,
+        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -76,6 +131,7 @@
     },
     "root": {
       "inputs": {
+        "hercules-ci-effects": "hercules-ci-effects",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       }
     }

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -3,6 +3,7 @@
   inputs = {
     pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "";
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
   };
   outputs = { ... }: { };
 }

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,8 @@
+{
+  description = "dependencies only";
+  inputs = {
+    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks-nix.inputs.nixpkgs.follows = "";
+  };
+  outputs = { ... }: { };
+}

--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -1,0 +1,2 @@
+# mdbook
+book

--- a/doc/manual/book.toml
+++ b/doc/manual/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "NixOps4 Reference Manual"
+
+[output.html]
+edit-url-template = "https://github.com/nixops4/nixops4/tree/master/doc/manual/{path}"
+git-repository-url = "https://github.com/nixops4/nixops4"
+git-repository-icon = "fa-github"
+
+[output.html.print]
+enable = false  # big single page: not needed, bad UX, possibly bad for SEO

--- a/doc/manual/flake-module.nix
+++ b/doc/manual/flake-module.nix
@@ -1,0 +1,6 @@
+{
+  perSystem = { config, pkgs, ... }: {
+    packages.manual = pkgs.callPackage ./package.nix { };
+    checks.manual-links = pkgs.callPackage ./test.nix { site = config.packages.manual; };
+  };
+}

--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, mdbook
+,
+}:
+let
+  inherit (lib) fileset;
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "nixops-manual";
+
+  src = fileset.toSource {
+    fileset = fileset.unions [
+      ./book.toml
+      ./src
+    ];
+    root = ./.;
+  };
+  strictDeps = true;
+  nativeBuildInputs = [
+    mdbook
+  ];
+  buildPhase = ''
+    runHook preBuild
+    mdbook build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    docDir="$out/share/doc/nixops4/manual"
+    mkdir -p "$docDir"
+    mv book/ "$docDir/html"
+    runHook postInstall
+  '';
+  allowedReferences = [ ];
+
+  passthru = {
+    html = finalAttrs.finalPackage.out + "/share/doc/nixops4/manual/html";
+  };
+})

--- a/doc/manual/src/SUMMARY.md
+++ b/doc/manual/src/SUMMARY.md
@@ -1,0 +1,5 @@
+- [Introduction](./index.md)
+  - [Resource](./concept/resource.md)
+- [Resource Provider](./resource-provider/index.md)
+  - [Resource Provider Interface](./resource-provider/interface.md)
+- [Index](./index/index.md)

--- a/doc/manual/src/concept/resource.md
+++ b/doc/manual/src/concept/resource.md
@@ -1,0 +1,3 @@
+# Resource
+
+A NixOps _resource_ is a unit of configuration that represents a certain real world entity.

--- a/doc/manual/src/index.md
+++ b/doc/manual/src/index.md
@@ -1,0 +1,4 @@
+
+# Introduction
+
+NixOps4 is a declarative and extensible tool for deploying and managing various types of machines and services.

--- a/doc/manual/src/index/index.md
+++ b/doc/manual/src/index/index.md
@@ -1,0 +1,4 @@
+
+# Index
+
+- [resource](../concept/resource.md)

--- a/doc/manual/src/resource-provider/index.md
+++ b/doc/manual/src/resource-provider/index.md
@@ -1,0 +1,3 @@
+# Resource Provider
+
+A _resource provider_ is the component that is responsible for carrying out the operations that create, update, and delete the real world entity that a resource represents.

--- a/doc/manual/src/resource-provider/interface.md
+++ b/doc/manual/src/resource-provider/interface.md
@@ -1,0 +1,3 @@
+# Resource Provider Interface
+
+The resource provider interface is still in development.

--- a/doc/manual/test.nix
+++ b/doc/manual/test.nix
@@ -1,0 +1,4 @@
+{ testers, site }:
+testers.lycheeLinkCheck {
+  inherit site;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
         "type": "github"
       },
       "original": {
@@ -282,7 +282,7 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1724440177,
+        "lastModified": 1722555339,
         "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"

--- a/flake.lock
+++ b/flake.lock
@@ -56,22 +56,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -139,27 +123,6 @@
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -308,22 +271,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -342,29 +289,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1724227338,
-        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -413,8 +337,7 @@
         "flake-parts": "flake-parts",
         "nix": "nix",
         "nix-cargo-integration": "nix-cargo-integration",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {

--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           inputs.nix-cargo-integration.flakeModule
           inputs.flake-parts.flakeModules.partitions
           ./rust/nci.nix
+          ./doc/manual/flake-module.nix
         ];
         systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
         perSystem = { config, self', inputs', pkgs, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,6 @@
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = inputs@{ self, flake-parts, ... }:
@@ -17,83 +15,22 @@
       { inherit inputs; }
       ({ lib, ... }: {
         imports = [
-          inputs.pre-commit-hooks-nix.flakeModule
           inputs.nix-cargo-integration.flakeModule
+          inputs.flake-parts.flakeModules.partitions
           ./rust/nci.nix
         ];
         systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
         perSystem = { config, self', inputs', pkgs, ... }: {
-
           packages.default = config.packages.nixops4-release;
           packages.nix = inputs'.nix.packages.nix;
-
-          pre-commit.settings.hooks.nixpkgs-fmt.enable = true;
-          pre-commit.settings.hooks.rustfmt.enable = true;
-          pre-commit.settings.settings.rust.cargoManifestPath = "./rust/Cargo.toml";
-
-          # Check that we're using ///-style doc comments in Rust code.
-          #
-          # Unfortunately, rustfmt won't do this for us yet - at least not
-          # without nightly, and it might do too much.
-          pre-commit.settings.hooks.rust-doc-comments = {
-            enable = true;
-            files = "\\.rs$";
-            entry = "${pkgs.writeScript "rust-doc-comments" ''
-              #!${pkgs.runtimeShell}
-              set -uxo pipefail
-              grep -n -C3 --color=always -F '/**' "$@"
-              r=$?
-              set -e
-              if [ $r -eq 0 ]; then
-                echo "Please replace /**-style comments by /// style comments in Rust code."
-                exit 1
-              fi
-            ''}";
-          };
-
-          devShells.default = pkgs.mkShell {
-            name = "nixops4-devshell";
-            strictDeps = true;
-            inputsFrom = [ config.nci.outputs.nixops4-project.devShell ];
-            inherit (config.nci.outputs.nixops4-project.devShell.env)
-              LIBCLANG_PATH
-              BINDGEN_EXTRA_CLANG_ARGS
-              ;
-            NIX_DEBUG_INFO_DIRS =
-              let
-                # TODO: add to Nixpkgs lib
-                getDebug = pkg:
-                  if pkg?debug then pkg.debug
-                  else if pkg?lib then pkg.lib
-                  else pkg;
-              in
-              "${getDebug config.packages.nix}/lib/debug";
-            buildInputs = [
-              config.packages.nix
-            ];
-            nativeBuildInputs = [
-              pkgs.rust-analyzer
-              pkgs.nixpkgs-fmt
-              pkgs.rustfmt
-              pkgs.pkg-config
-              pkgs.clang-tools # clangd
-              pkgs.valgrind
-              pkgs.gdb
-              # TODO: set up cargo-valgrind in shell and build
-              #       currently both this and `cargo install cargo-valgrind`
-              #       produce a binary that says ENOENT.
-              # pkgs.cargo-valgrind
-            ];
-            shellHook = ''
-              ${config.pre-commit.installationScript}
-              echo 1>&2 "Welcome to the development shell!"
-            '';
-            # rust-analyzer needs a NIX_PATH for some reason
-            NIX_PATH = "nixpkgs=${inputs.nixpkgs}";
-          };
         };
-        flake = {
-          herculesCI.ciSystems = [ "x86_64-linux" ];
+
+        partitionedAttrs.devShells = "dev";
+        partitionedAttrs.checks = "dev";
+        partitionedAttrs.herculesCI = "dev";
+        partitions.dev.extraInputsFlake = ./dev;
+        partitions.dev.module = {
+          imports = [ ./dev/flake-module.nix ];
         };
       });
 }


### PR DESCRIPTION
- Create dev-only dependencies using https://github.com/hercules-ci/flake-parts/pull/242
  This prevents polluting consumers' lock files with dependencies for the site
- Add a mostly empty mdBook documentation site
- Deploy it to a directory in a git branch, `site-content` so that the site allows multiple versions to coexist
- I've configured netlify to deploy `site-content` to `nixops.dev`
- Other branches will be deployed to preview URLs

Preview: https://site--nixops-preview.netlify.app/manual/development/