### PR TITLE
fix: Deduplicate stores to work around nix#11979

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -594,7 +594,8 @@ mod tests {
     fn weak_ref_gone() {
         gc_registering_current_thread(|| {
             let weak = {
-                let store = Store::open("auto", HashMap::new()).unwrap();
+                // Use a slightly different URL which is unique in the test suite, to bypass the global store cache
+                let store = Store::open("auto?foo=bar", HashMap::new()).unwrap();
                 let es = EvalState::new(store, []).unwrap();
                 es.weak_ref()
             };


### PR DESCRIPTION
Fixes tests hanging. Before this commit:

    nix build .#packages.x86_64-linux.nixops4-eval-release

See https://github.com/NixOS/nix/issues/11979