### PR TITLE
fix: Use the restored flake-parts link format

### DIFF
--- a/doc/manual/deployment-option-docs-md.nix
+++ b/doc/manual/deployment-option-docs-md.nix
@@ -39,4 +39,12 @@ let
       opt.declarations;
   };
 in
-docs.optionsCommonMark
+docs.optionsCommonMark.overrideAttrs {
+  extraArgs = [
+    # Align with NixOS HTML manual and flake-parts
+    "--anchor-prefix"
+    "opt-"
+    "--anchor-style"
+    "legacy"
+  ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -212,11 +212,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
         "type": "github"
       },
       "original": {

--- a/nix/resourceType/resourceType.nix
+++ b/nix/resourceType/resourceType.nix
@@ -16,7 +16,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.executable`](#resourcesnameproviderexecutable).
+        Value to be used for [`resources.<name>.provider.executable`](#opt-nixops4Deployments._name_.providers._name_.executable).
       '';
     };
 
@@ -27,7 +27,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.args`](#resourcesnameproviderargs).
+        Value to be used for [`resources.<name>.provider.args`](#opt-nixops4Deployments._name_.providers._name_.args).
       '';
     };
 
@@ -38,7 +38,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.type`](#resourcesnameprovidertype).
+        Value to be used for [`resources.<name>.provider.type`](#opt-nixops4Deployments._name_.providers._name_.type).
       '';
     };
 

--- a/nix/resourceType/resourceType.nix
+++ b/nix/resourceType/resourceType.nix
@@ -2,9 +2,33 @@
   This type has a lot in common with the `resource.nix` module, but it only
   contains static "metadata", which is a significant difference
 */
-{ config, lib, provider, ... }:
+{ config, lib, provider, options, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption replaceStrings showOption types;
+
+  # Polyfill https://github.com/NixOS/nixpkgs/pull/370558
+  dropEnd = lib.dropEnd or
+    (n: xs:
+      lib.lists.take
+        (lib.max 0 (lib.lists.length xs - n))
+        xs);
+
+  moduleLoc = dropEnd 2 options.provider.executable.loc;
+
+  docResources =
+    dropEnd
+      # usually mounted on providers.<name>.resourceTypes.<name>
+      4
+      moduleLoc
+    ++ [ "resources" ];
+
+  # Incomplete, but good enough for now
+  renderFragment = loc:
+    replaceStrings [ "<" ">" ] [ "_" "_" ]
+      (showOption loc);
+
+  linkOptionLoc = loc:
+    "[`" + showOption loc + "`](#opt-" + renderFragment loc + ")";
 in
 {
   _class = "nixops4ResourceType";
@@ -16,7 +40,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.executable`](#opt-nixops4Deployments._name_.providers._name_.executable).
+        Value to be used for ${linkOptionLoc (docResources ++ ["<name>" "provider" "executable"])}.
       '';
     };
 
@@ -27,7 +51,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.args`](#opt-nixops4Deployments._name_.providers._name_.args).
+        Value to be used for ${linkOptionLoc (docResources ++ ["<name>" "provider" "args"])}.
       '';
     };
 
@@ -38,7 +62,7 @@ in
         inherited from provider
       '';
       description = ''
-        Value to be used for [`resources.<name>.provider.type`](#opt-nixops4Deployments._name_.providers._name_.type).
+        Value to be used for ${linkOptionLoc (docResources ++ ["<name>" "provider" "type"])}.
       '';
     };
 


### PR DESCRIPTION
Originally wrote this for a WIP branch of flake.parts-website where the link fragments were broken. That's been fixed now.

Context
- https://github.com/hercules-ci/flake.parts-website/pull/1295