### PR TITLE
unpin ratatui - solves error 'cannot find Git revision ...'

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -936,8 +936,9 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
-source = "git+https://github.com/ratatui/ratatui?rev=0bb42842ebbea5adcbfbf2251b66994415355ef1#0bb42842ebbea5adcbfbf2251b66994415355ef1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",

--- a/rust/nixops4/Cargo.toml
+++ b/rust/nixops4/Cargo.toml
@@ -29,8 +29,7 @@ tracing-subscriber = { version = "0.3.18", features = ["registry"] }
 nix = "0.29.0"
 crossterm = "0.28.1"
 ansi-parser = "0.9.1"
-# https://github.com/ratatui/ratatui/pull/1427
-ratatui = { git = "https://github.com/ratatui/ratatui", rev = "0bb42842ebbea5adcbfbf2251b66994415355ef1", features = [ "unstable-rendered-line-info" ] }
+ratatui = "0.29.0"
 ctrlc = "3.4.5"
 
 [[bin]]


### PR DESCRIPTION
solves error:

> error: Cannot find Git revision
'0bb42842ebbea5adcbfbf2251b66994415355ef1' in ref 'master' of repository 'https://github.com/ratatui/ratatui'! Please make sure that the rev exists on the ref you've specified or add allRefs = true; to fetchGit.
