### PR TITLE
Stateful resource support (prototype)

### DIFF
--- a/example/flake.lock
+++ b/example/flake.lock
@@ -1,0 +1,465 @@
+{
+  "nodes": {
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727316705,
+        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.19.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1735160684,
+        "narHash": "sha256-n5CwhmqKxifuD4Sq4WuRP/h5LO6f23cGnSAuJemnd/4=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "8ce6284ff58208ed8961681276f82c2f8f978ef4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "nixops4",
+          "nix"
+        ],
+        "gitignore": [
+          "nixops4",
+          "nix"
+        ],
+        "nixpkgs": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "mk-naked-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681286841,
+        "narHash": "sha256-3XlJrwlR0nBiREnuogoa5i1b4+w/XPe0z8bbrJASw0g=",
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "rev": "7612f828dd6f22b7fb332cc69440e839d7ffe6bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1744095711,
+        "narHash": "sha256-Aqnj5+sA7B4ZRympuyfWPPK83iomKHEHMYhlwslI8iA=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "e76bbe413e86e3208bb9824e339d59af25327101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-cargo-integration": {
+      "inputs": {
+        "crane": "crane",
+        "dream2nix": "dream2nix",
+        "mk-naked-shell": "mk-naked-shell",
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ],
+        "parts": "parts",
+        "rust-overlay": "rust-overlay",
+        "treefmt": "treefmt"
+      },
+      "locked": {
+        "lastModified": 1743488269,
+        "narHash": "sha256-G4IRYK7vG2kA9Xr1KwXJH1SVc57qNPlQXBl6d/V6LSc=",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "rev": "be686c02a3fbad61448abcc2049a9178a4cd903c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "type": "github"
+      }
+    },
+    "nixops4": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix": "nix",
+        "nix-cargo-integration": "nix-cargo-integration",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old"
+      },
+      "locked": {
+        "path": "..",
+        "type": "path"
+      },
+      "original": {
+        "path": "..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702448246,
+        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
+        "owner": "davhau",
+        "repo": "pyproject.nix",
+        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "dream2nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": [
+          "nixops4",
+          "flake-parts"
+        ],
+        "nixops4": "nixops4",
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743475035,
+        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -28,7 +28,14 @@
         resources.test3 = {
           type = providers.local.memo;
           state = "state";
-          inputs.initialize_with = { hello = "world"; };
+          inputs.initialize_with = { hello = "World"; };
+        };
+        resources.version_file = {
+          type = providers.local.file;
+          inputs = {
+            name = "version.txt";
+            contents = "version: ${resources.test3.value.hello}";
+          };
         };
 
         resources.demoA = {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    # flake-parts.url = "github:hercules-ci/flake-parts";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # stack overflow, Nix bug in call-flake.nix?
+    flake-parts.follows = "nixops4/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    nixpkgs.follows = "nixops4/nixpkgs";
+    nixops4.url = ../.;
+  };
+
+  outputs = inputs@{ flake-parts, nixops4, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        nixops4.modules.flake.default
+      ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: { };
+      # nixops4 apply --override-input nixops4 ..
+      nixops4Deployments.default = { providers, resources, ... }: {
+        providers.local = nixops4.modules.nixops4Provider.local;
+        resources.state = {
+          type = providers.local.state_file;
+          inputs.name = "nixops4-state.json";
+        };
+        resources.test3 = {
+          type = providers.local.memo;
+          state = "state";
+          inputs.initialize_with = { hello = "world"; };
+        };
+
+        resources.demoA = {
+          type = providers.local.exec;
+          inputs = {
+            executable = "sh";
+            args = [ "-c" "sleep 1; echo hello ${resources.demoB.stdout}" ];
+          };
+        };
+        resources.demoB = {
+          type = providers.local.exec;
+          inputs = {
+            executable = "sh";
+            args = [ "-c" "sleep 1; echo world" ];
+          };
+        };
+        resources.demoC = {
+          type = providers.local.exec;
+          inputs = {
+            executable = "sh";
+            args = [ "-c" "sleep 1; echo hello ${resources.demoB.stdout}" ];
+          };
+        };
+        resources.demoD = {
+          type = providers.local.exec;
+          inputs = {
+            executable = "sh";
+            args = [ "-c" "sleep 1; echo it says ${resources.demoC.stdout}" ];
+          };
+        };
+        # resource
+
+        # resources.helloA = {
+        #   type = providers.local.exec;
+        #   inputs.executable = resources.helloB.stdout;
+        # };
+        # resources.helloB = {
+        #   type = providers.local.exec;
+        #   inputs.executable = resources.helloA.stdout;
+        # };
+        # resources.test2 = {
+        #   type = builtins.seq resources.test3.value providers.local.memo;
+        #   state = "state";
+        #   inputs.initialize_with = { hello = "world"; };
+        # };
+      };
+      flake = { };
+    };
+}

--- a/nix/deployment/providers.nix
+++ b/nix/deployment/providers.nix
@@ -65,7 +65,15 @@ in
   config = {
     _module.args.providers = lib.mapAttrs
       (name: provider:
-        provider.resourceTypes
+        lib.mapAttrs
+          (k: v:
+            # Set the _type, so that an accidental use in `imports` gets caught
+            # and reported in a comprehensible way.
+            v // {
+              /** A NixOps4 Resource Type can be used in the resouce `type` option. */
+              _type = "nixops4ResourceType";
+            })
+          provider.resourceTypes
       )
       config.providers;
   };

--- a/nix/deployment/providers.nix
+++ b/nix/deployment/providers.nix
@@ -19,6 +19,7 @@ let
       provider.args = config.type.provider.args;
       resourceType = config.type.type;
       outputsSkeleton = config.type.outputsSkeleton;
+      requireState = config.type.requireState;
       inputs = { ... }: { imports = [ config.type.inputs ]; };
       outputs = { ... }: { imports = [ config.type.outputs ]; };
     };

--- a/nix/deployment/resource.nix
+++ b/nix/deployment/resource.nix
@@ -1,7 +1,7 @@
 /**
   A reification of the resource interface between the language and nixops4.
  */
-{ config, lib, ... }:
+{ config, lib, options, ... }:
 let
   inherit (lib) mkOption types;
 in
@@ -47,6 +47,14 @@ in
         Whether the resource requires state to be stored.
       '';
     };
+    state = mkOption {
+      type = types.nullOr types.str;
+      description = ''
+        The state handler for the resource, if needed.
+      '';
+      default = null;
+      apply = x: lib.throwIf (config.requireState && x == null) "${options.state} ${if options.state.highestPrio >= lib.modules.defaultOverridePriority then "has not been defined" else "must not be null"}" x;
+    };
     inputs = mkOption {
       type = types.submodule { };
       description = ''
@@ -77,7 +85,7 @@ in
   };
   config = {
     _resourceForNixOps = {
-      inherit (config) provider inputs outputsSkeleton;
+      inherit (config) provider inputs outputsSkeleton state;
       type = config.resourceType;
     };
   };

--- a/nix/deployment/resource.nix
+++ b/nix/deployment/resource.nix
@@ -41,6 +41,12 @@ in
         The type of resource to create. Most resource providers will have some fixed set of resource types.
       '';
     };
+    requireState = mkOption {
+      type = types.bool;
+      description = ''
+        Whether the resource requires state to be stored.
+      '';
+    };
     inputs = mkOption {
       type = types.submodule { };
       description = ''

--- a/nix/lib/tests.nix
+++ b/nix/lib/tests.nix
@@ -35,6 +35,7 @@ in
                 type = types.str;
               };
             };
+            requireState = false;
             outputs = {
               options.stdout = mkOption {
                 type = types.str;
@@ -69,6 +70,7 @@ in
                     type = "stdio";
                   };
                   inputs = { };
+                  requireState = false;
                   outputs = { ... }: {
                     options.aResult = mkOption {
                       type = types.str;
@@ -94,6 +96,8 @@ in
                   config.a = resources.a.aResult;
                   config.a2 = config.resources.a.outputs.aResult;
                 };
+                requireState = true;
+                state = "a";
                 outputs = { };
                 outputsSkeleton = { };
               };
@@ -145,6 +149,7 @@ in
                 executable = "/foo/bin/agree";
                 type = "stdio";
               };
+              state = null;
               type = "aye";
               outputsSkeleton = { aResult = { }; };
             };
@@ -158,6 +163,7 @@ in
                 executable = "/foo/bin/bee";
                 type = "stdio";
               };
+              state = "a";
               type = "bee";
               outputsSkeleton = { };
             };
@@ -170,6 +176,7 @@ in
                 executable = "/fake/store/asdf-nixops4-resources-local/bin/nixops4-resources-local";
                 type = "stdio";
               };
+              state = null;
               type = "exec";
               outputsSkeleton = { stdout = { }; };
             };

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -11,8 +11,8 @@ in
       "${config.packages.nixops4-resources-local-release}/bin/nixops4-resources-local"
     );
   resourceTypes = {
-    requireState = false;
     file = {
+      requireState = false;
       inputs = {
         options = {
           name = mkOption {

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -27,6 +27,19 @@ in
         options = { };
       };
     };
+    state_file = {
+      requireState = false;
+      inputs = {
+        options = {
+          name = mkOption {
+            type = types.str;
+          };
+        };
+      };
+      outputs = {
+        options = { };
+      };
+    };
     exec = {
       requireState = false;
       inputs = {

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -52,5 +52,30 @@ in
         };
       };
     };
+    memo = {
+      requireState = true;
+      inputs = {
+        options = {
+          initialize_with = mkOption {
+            # TODO: types.json?
+            type = types.anything;
+            description = ''
+              The initial value of the memo.
+              The memo is _not_ updated if this value changes in later versions of your deployment expression.
+            '';
+          };
+        };
+      };
+      outputs = {
+        options = {
+          value = mkOption {
+            type = types.anything;
+            description = ''
+              The value of the memo, which is the value of the `initialize_with` input *when the memo was created*.
+            '';
+          };
+        };
+      };
+    };
   };
 }

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -11,6 +11,7 @@ in
       "${config.packages.nixops4-resources-local-release}/bin/nixops4-resources-local"
     );
   resourceTypes = {
+    requireState = false;
     file = {
       inputs = {
         options = {
@@ -27,6 +28,7 @@ in
       };
     };
     exec = {
+      requireState = false;
       inputs = {
         options = {
           executable = mkOption {

--- a/nix/resourceType/resourceType.nix
+++ b/nix/resourceType/resourceType.nix
@@ -100,6 +100,13 @@ in
       '';
     };
 
+    requireState = mkOption {
+      type = types.bool;
+      description = ''
+        Whether the resource requires state to be stored.
+      '';
+    };
+
     type = mkOption {
       type = types.str;
       description = ''

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.37",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -437,19 +437,30 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "foldhash"
@@ -462,6 +473,18 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
 
 [[package]]
 name = "gimli"
@@ -607,6 +630,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,9 +665,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -639,6 +684,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -695,7 +746,7 @@ dependencies = [
  "hermit-abi",
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -875,9 +926,13 @@ name = "nixops4-resources-local"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "fd-lock",
+ "json-patch",
  "nixops4-resource",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -998,6 +1053,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1141,8 +1202,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1365,14 +1439,24 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "rustix",
- "windows-sys 0.52.0",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1381,7 +1465,18 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1522,7 +1617,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "thiserror",
+ "thiserror 2.0.12",
  "unicode-ident",
 ]
 
@@ -1597,6 +1692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,7 +1767,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.37",
 ]
 
 [[package]]
@@ -1894,3 +1998,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "tracing",
  "typify",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -709,7 +709,19 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
 dependencies = [
- "jsonptr",
+ "jsonptr 0.6.3",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "json-patch"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+dependencies = [
+ "jsonptr 0.7.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -720,6 +732,16 @@ name = "jsonptr"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
@@ -920,6 +942,7 @@ dependencies = [
  "clap_mangen",
  "crossterm",
  "ctrlc",
+ "json-patch 4.0.0",
  "lazy_static",
  "nix",
  "nixops4-core",
@@ -1008,7 +1031,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "fd-lock",
- "json-patch",
+ "json-patch 3.0.1",
  "nixops4-resource",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -113,10 +113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
+name = "async-channel"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -357,10 +369,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -418,6 +445,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +484,27 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -473,6 +535,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "getrandom"
@@ -506,6 +574,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -653,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -713,7 +787,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -839,19 +913,23 @@ version = "0.1.0"
 dependencies = [
  "ansi-parser",
  "anyhow",
+ "async-trait",
  "clap",
  "clap-markdown",
  "clap_complete",
  "clap_mangen",
  "crossterm",
  "ctrlc",
+ "lazy_static",
  "nix",
  "nixops4-core",
  "nixops4-resource",
  "nixops4-resource-runner",
+ "pubsub-rs",
  "ratatui",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-tunnel",
@@ -919,6 +997,7 @@ dependencies = [
  "nixops4-resource",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 
@@ -987,6 +1066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pubsub-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cba7b19d46ae57a9a6307681961fd24ab5e2794e4cc7e2e711cacfa733f610b"
+dependencies = [
+ "async-channel",
+ "dashmap",
+ "tokio",
 ]
 
 [[package]]
@@ -1163,7 +1259,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.0",
  "memchr",
 ]
 
@@ -1378,6 +1474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "socket2"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,21 +1609,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/nixops4-core/src/eval_api.rs
+++ b/rust/nixops4-core/src/eval_api.rs
@@ -186,7 +186,7 @@ pub struct ResourceInputDependency {
     pub dependency: Dependency,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Dependency {
     ResourceOutput { property: NamedProperty },
     State { resource: String },
@@ -206,7 +206,7 @@ impl Dependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NamedProperty {
     pub resource: String,
     pub name: String,

--- a/rust/nixops4-core/src/eval_api.rs
+++ b/rust/nixops4-core/src/eval_api.rs
@@ -182,7 +182,27 @@ pub struct ResourceProviderInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceInputDependency {
     pub dependent: Property,
-    pub dependency: NamedProperty,
+    pub dependency: Dependency,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Dependency {
+    ResourceOutput { property: NamedProperty },
+    State { resource: String },
+}
+impl Dependency {
+    pub fn resource_name(&self) -> &String {
+        match self {
+            Dependency::ResourceOutput { property } => &property.resource,
+            Dependency::State { resource } => resource,
+        }
+    }
+    pub fn property_name(&self) -> Option<&String> {
+        match self {
+            Dependency::ResourceOutput { property } => Some(&property.name),
+            Dependency::State { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -196,6 +216,12 @@ pub struct NamedProperty {
 pub struct Property {
     pub resource: Id<ResourceType>,
     pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum DependencyById {
+    ResourceOutput { property: Property },
+    State { resource: Id<ResourceType> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/nixops4-core/src/eval_api.rs
+++ b/rust/nixops4-core/src/eval_api.rs
@@ -177,6 +177,7 @@ pub struct ResourceProviderInfo {
     pub id: Id<ResourceType>,
     pub provider: Value,
     pub resource_type: String,
+    pub state: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/nixops4-eval/src/eval.rs
+++ b/rust/nixops4-eval/src/eval.rs
@@ -10,8 +10,8 @@ use nix_expr::{
     value::Value,
 };
 use nixops4_core::eval_api::{
-    AssignRequest, EvalRequest, EvalResponse, FlakeType, Id, IdNum, NamedProperty, QueryRequest,
-    QueryResponseValue, RequestIdType, ResourceInputDependency, ResourceInputState,
+    AssignRequest, Dependency, EvalRequest, EvalResponse, FlakeType, Id, IdNum, NamedProperty,
+    QueryRequest, QueryResponseValue, RequestIdType, ResourceInputDependency, ResourceInputState,
     ResourceProviderInfo, ResourceType,
 };
 use std::sync::{Arc, Mutex};
@@ -447,7 +447,9 @@ fn perform_get_resource_input(
                 Ok(ResourceInputState::ResourceInputDependency(
                     ResourceInputDependency {
                         dependent: req.to_owned(),
-                        dependency: named_property,
+                        dependency: Dependency::ResourceOutput {
+                            property: named_property,
+                        },
                     },
                 ))
             } else {

--- a/rust/nixops4-resource-runner/Cargo.toml
+++ b/rust/nixops4-resource-runner/Cargo.toml
@@ -21,6 +21,7 @@ nixops4-resource = { path = "../nixops4-resource" }
 serde = "1.0.209"
 serde_json = "1.0.127"
 tracing = "0.1.41"
+tokio = { version = "1.44.2", features = ["io-util", "process", "rt"] }
 
 [lib]
 path = "src/lib.rs"

--- a/rust/nixops4-resource-runner/src/lib.rs
+++ b/rust/nixops4-resource-runner/src/lib.rs
@@ -1,8 +1,15 @@
-use std::io::{BufRead, Write};
+use std::{
+    collections::BTreeMap,
+    io::{BufRead, BufReader, BufWriter, Write},
+    process,
+};
 
 use anyhow::{Context, Result};
-use nixops4_resource::schema::v0::{CreateResourceRequest, CreateResourceResponse};
-use serde_json::Value;
+use nixops4_resource::schema::v0;
+use nixops4_resource::schema::v0::{
+    CreateResourceRequest, Request, Response,
+};
+use serde_json::{json, Value};
 use tracing::warn;
 
 pub struct ResourceProviderConfig {
@@ -12,93 +19,110 @@ pub struct ResourceProviderConfig {
 
 pub struct ResourceProviderClient {
     provider_config: ResourceProviderConfig,
-    // TODO: maintain a long-lived process
+    process: process::Child,
+    child_reader: BufReader<process::ChildStdout>,
+    /// None: close stdin to let the provider shut down
+    child_writer: Option<BufWriter<process::ChildStdin>>,
 }
 
 impl ResourceProviderClient {
-    pub fn new(provider_config: ResourceProviderConfig) -> Self {
-        ResourceProviderClient { provider_config }
+    pub fn new(provider_config: ResourceProviderConfig) -> Result<Self> {
+        let mut process = std::process::Command::new(provider_config.provider_executable.clone())
+            .args(provider_config.provider_args.clone())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "Could not spawn provider process {}",
+                    provider_config.provider_executable
+                )
+            })?;
+        let child_reader = std::io::BufReader::new(process.stdout.take().unwrap());
+        let child_writer = std::io::BufWriter::new(process.stdin.take().unwrap());
+        Ok(ResourceProviderClient {
+            provider_config,
+            process,
+            child_reader,
+            child_writer: Some(child_writer),
+        })
+    }
+
+    fn get_writer(&mut self) -> Result<&mut BufWriter<process::ChildStdin>> {
+        self.child_writer.as_mut().ok_or_else(|| {
+            anyhow::anyhow!("Can not write to provider while provider is shutting down.")
+        })
+    }
+
+    fn write_request(&mut self, req: Request) -> Result<()> {
+        let stdin_str = serde_json::to_string(&req).unwrap();
+        let writer = self.get_writer()?;
+        writer.write_all(stdin_str.as_bytes()).unwrap();
+        writer.write_all(b"\n").unwrap();
+        writer.flush().unwrap();
+        Ok(())
+    }
+
+    fn read_response(&mut self) -> Result<Response> {
+        let mut response = String::new();
+        let n = self.child_reader.read_line(&mut response);
+        match n {
+            Err(e) => {
+                anyhow::bail!("Error reading from provider process: {}", e);
+            }
+            // EOF
+            Ok(0) => {
+                // Log it
+                warn!("Provider process did not return any output");
+
+                // Wait for the process to finish
+                let r = self.process.wait()?;
+
+                if r.success() {
+                    anyhow::bail!("Provider process did not return any output");
+                } else {
+                    bail_provider_exit_code(r)?
+                }
+            }
+            Ok(_) => Ok(serde_json::from_str(&response)?),
+        }
     }
 
     pub fn create(
-        &self,
+        &mut self,
         type_: &str,
         inputs: &serde_json::Map<String, Value>,
     ) -> Result<serde_json::Map<String, Value>> {
-        let stdin_str = {
-            let req = CreateResourceRequest {
-                input_properties: inputs.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-                type_: type_.to_string(),
-            };
-            serde_json::to_string(&req).unwrap()
+        let req = CreateResourceRequest {
+            input_properties: v0::InputProperties(
+                inputs.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            ),
+            type_: v0::ResourceType(type_.to_string()),
+            is_stateful: false,
         };
 
-        let mut process =
-            std::process::Command::new(self.provider_config.provider_executable.clone())
-                .args(self.provider_config.provider_args.clone())
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .with_context(|| {
-                    format!(
-                        "Could not spawn provider process {}",
-                        self.provider_config.provider_executable
-                    )
-                })?;
+        // Write the request
+        self.write_request(v0::Request::CreateResourceRequest(
+            req,
+        ))?;
 
-        // Get the handles
-        let (response, mut process) = {
-            let child_in = process.stdin.as_mut().unwrap();
-            let child_out = process.stdout.as_mut().unwrap();
-            let mut child_reader = std::io::BufReader::new(child_out);
-
-            // Write the request
-            child_in.write_all(stdin_str.as_bytes()).unwrap();
-            child_in.write_all(b"\n").unwrap();
-            child_in.flush().unwrap();
-
-            // Read the response
-            let response: CreateResourceResponse = {
-                let mut response = String::new();
-                let n = child_reader.read_line(&mut response);
-                match n {
-                    Err(e) => {
-                        anyhow::bail!("Error reading from provider process: {}", e);
-                    }
-                    // EOF
-                    Ok(0) => {
-                        // Log it
-                        warn!("Provider process did not return any output");
-
-                        // Wait for the process to finish
-                        let r = process.wait()?;
-
-                        if r.success() {
-                            anyhow::bail!("Provider process did not return any output");
-                        } else {
-                            bail_provider_exit_code(r)?
-                        }
-                    }
-                    Ok(_) => serde_json::from_str(&response)?,
-                }
-            };
-            (response, process)
-            // This closes stdin
-        };
-
-        // Wait for the process to finish
-        let r = process.wait()?;
-
-        if !r.success() {
-            bail_provider_exit_code(r)?
+        let response = self.read_response()?;
+        match response {
+            v0::Response::CreateResourceResponse(r) => Ok(r.output_properties),
+            _ => anyhow::bail!("Unexpected response from provider: {:?}", response),
         }
-
-        Ok(response
-            .output_properties
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect())
+    }
+}
+impl Drop for ResourceProviderClient {
+    fn drop(&mut self) {
+        // Close stdin to let the provider shut down
+        drop(self.child_writer.take());
+        // Wait for the process to finish
+        let r = self.process.wait().unwrap();
+        if !r.success() {
+            warn!("Provider process failed with exit code: {}", r);
+        }
     }
 }
 

--- a/rust/nixops4-resource-runner/src/main.rs
+++ b/rust/nixops4-resource-runner/src/main.rs
@@ -64,10 +64,10 @@ fn main() -> Result<()> {
                 inputs.insert(k.clone(), serde_json::Value::String(v.clone()));
             }
 
-            let provider = ResourceProviderClient::new(ResourceProviderConfig {
+            let mut provider = ResourceProviderClient::new(ResourceProviderConfig {
                 provider_executable: provider_exe.clone(),
                 provider_args: vec![],
-            });
+            })?;
 
             let result = provider
                 .create(resource_type, &inputs)

--- a/rust/nixops4-resource/Cargo.toml
+++ b/rust/nixops4-resource/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.79"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 nix = { version = "0.29.0", features = ["fs"] }
+tracing = "0.1.40"
 chrono = { version = "0.4.41", features = ["serde"] }
 
 [lib]

--- a/rust/nixops4-resource/Cargo.toml
+++ b/rust/nixops4-resource/Cargo.toml
@@ -3,6 +3,7 @@ name = "nixops4-resource"
 version = "0.1.0"
 description = "A library for the NixOps resource provider interface"
 edition = "2021"
+build = "build.rs"
 license = "LGPL-2.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/nixops4-resource/examples/v0/CreateResourceRequest.json
+++ b/rust/nixops4-resource/examples/v0/CreateResourceRequest.json
@@ -3,5 +3,6 @@
   "inputProperties": {
     "path": "pubkey.txt",
     "content": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD"
-  }
+  },
+  "isStateful": false
 }

--- a/rust/nixops4-resource/resource-schema-v0.json
+++ b/rust/nixops4-resource/resource-schema-v0.json
@@ -171,12 +171,15 @@
         },
         "event": {
           "type": "string",
+          "description": "The operation that produced this change."
+        },
+        "nixopsVersion": {
+          "type": "string",
           "title": "NixOps version",
           "description": "The version of NixOps that is running, for posterity and forward compatibility."
         },
         "patch": {
-          "type": "object",
-          "additionalProperties": true,
+          "type": "array",
           "title": "Patch",
           "description": "A JSON Patch <https://datatracker.ietf.org/doc/html/rfc6902> that describes the changes to the combined state of all managed resources. This method is only implemented by resources that function as a state storage. NixOps4 takes great care to make sure that the patch can be applied, but if it does not, the patch must be saved."
         }
@@ -184,6 +187,7 @@
       "required": [
         "resource",
         "event",
+        "nixopsVersion",
         "patch"
       ],
       "additionalProperties": false

--- a/rust/nixops4-resource/resource-schema-v0.json
+++ b/rust/nixops4-resource/resource-schema-v0.json
@@ -3,24 +3,79 @@
   "title": "NixOps4 Resource Protocol Schema",
   "description": "This schema describes the protocol between NixOps4 and a resource provider. See doc/developing-resources.md for more information.",
   "definitions": {
-    "CreateResourceRequest": {
+    "resourceType": {
+      "type": "string",
+      "title": "Provider-defined resource type",
+      "description": "The type of the resource to create. The resource provider uses this to distinguish between different types of resources that it manages. Furthermore, the type will be shown to the user."
+    },
+    "inputProperties": {
+      "type": "object",
+      "additionalProperties": true,
+      "title": "Input properties",
+      "description": "Arbitrary fields that make up the input properties. The set of valid fields is determined by the resource provider implementation. If any unrecognized fields are present, the resource provider must not proceed and return an error."
+    },
+    "outputProperties": {
+      "type": "object",
+      "additionalProperties": true,
+      "title": "Output properties",
+      "description": "Arbitrary fields that make up the output properties. The set of fields is determined by the resource provider implementation. Unknown fields will be ignored by the Nix expressions."
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Arbitrary metadata to store with a state update event",
+      "properties": {
+        "nixopsVersion": {
+          "type": "string",
+          "title": "NixOps version",
+          "description": "The version of NixOps that is running, for posterity and forward compatibility."
+        },
+        "time": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The time at which the event was registered."
+        }
+      }
+    },
+    "ExtantResource": {
       "type": "object",
       "properties": {
         "type": {
-          "type": "string",
-          "title": "Provider-defined resource type",
-          "description": "The type of the resource to create. The resource provider uses this to distinguish between different types of resources that it manages. Furthermore, the type will be shown to the user."
+          "$ref": "#/definitions/resourceType"
         },
         "inputProperties": {
-          "type": "object",
-          "additionalProperties": true,
-          "title": "Input properties",
-          "description": "Arbitrary fields that make up the input properties. The set of valid fields is determined by the resource provider implementation. If any unrecognized fields are present, the resource provider must not proceed and return an error."
+          "$ref": "#/definitions/inputProperties"
+        },
+        "outputProperties": {
+          "$ref": "#/definitions/outputProperties"
         }
       },
       "required": [
         "type",
         "inputProperties"
+      ],
+      "additionalProperties": false
+    },
+    "CreateResourceRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/resourceType"
+        },
+        "inputProperties": {
+          "$ref": "#/definitions/inputProperties"
+        },
+        "isStateful": {
+          "type": "boolean",
+          "title": "Stateful resource",
+          "description": "Whether the resource is declared to be stateful. If false, the response will not be persisted."
+        }
+      },
+      "required": [
+        "type",
+        "inputProperties",
+        "isStateful"
       ],
       "additionalProperties": false
     },
@@ -38,11 +93,345 @@
         "outputProperties"
       ],
       "additionalProperties": false
+    },
+    "ReadResourceRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/ExtantResource"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "additionalProperties": false
+    },
+    "ReadResourceResponse": {
+      "type": "object",
+      "properties": {
+        "outputProperties": {
+          "$ref": "#/definitions/outputProperties"
+        }
+      },
+      "required": [
+        "outputProperties"
+      ],
+      "additionalProperties": false
+    },
+    "UpdateResourceRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/ExtantResource"
+        },
+        "inputProperties": {
+          "$ref": "#/definitions/inputProperties"
+        }
+      },
+      "required": [
+        "resource",
+        "inputProperties"
+      ],
+      "additionalProperties": false
+    },
+    "UpdateResourceResponse": {
+      "type": "object",
+      "properties": {
+        "outputProperties": {
+          "$ref": "#/definitions/outputProperties"
+        }
+      },
+      "required": [
+        "outputProperties"
+      ],
+      "additionalProperties": false
+    },
+    "DestroyResourceRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/ExtantResource"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "additionalProperties": false
+    },
+    "DestroyResourceResponse": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "StateResourceEvent": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/ExtantResource"
+        },
+        "event": {
+          "type": "string",
+          "title": "NixOps version",
+          "description": "The version of NixOps that is running, for posterity and forward compatibility."
+        },
+        "patch": {
+          "type": "object",
+          "additionalProperties": true,
+          "title": "Patch",
+          "description": "A JSON Patch <https://datatracker.ietf.org/doc/html/rfc6902> that describes the changes to the combined state of all managed resources. This method is only implemented by resources that function as a state storage. NixOps4 takes great care to make sure that the patch can be applied, but if it does not, the patch must be saved."
+        }
+      },
+      "required": [
+        "resource",
+        "event",
+        "patch"
+      ],
+      "additionalProperties": false
+    },
+    "StateResourceEventResponse": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "StateResourceReadRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/ExtantResource"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "additionalProperties": false
+    },
+    "StateResourceReadResponse": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "object",
+          "additionalProperties": true,
+          "title": "State",
+          "description": "The state of all the managed resources. This method is only implemented by resources that function as a state storage."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "additionalProperties": false
+    },
+    "Request": {
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "CreateResourceRequest",
+          "properties": {
+            "type": {
+              "const": "CreateResourceRequest"
+            },
+            "data": {
+              "$ref": "#/definitions/CreateResourceRequest"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "ReadResourceRequest",
+          "properties": {
+            "type": {
+              "const": "ReadResourceRequest"
+            },
+            "data": {
+              "$ref": "#/definitions/ReadResourceRequest"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "UpdateResourceRequest",
+          "properties": {
+            "type": {
+              "const": "UpdateResourceRequest"
+            },
+            "data": {
+              "$ref": "#/definitions/UpdateResourceRequest"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "DestroyResourceRequest",
+          "properties": {
+            "type": {
+              "const": "DestroyResourceRequest"
+            },
+            "data": {
+              "$ref": "#/definitions/DestroyResourceRequest"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "StateResourceEvent",
+          "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
+          "properties": {
+            "type": {
+              "const": "StateResourceEvent"
+            },
+            "data": {
+              "$ref": "#/definitions/StateResourceEvent"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "StateResourceReadRequest",
+          "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
+          "properties": {
+            "type": {
+              "const": "StateResourceReadRequest"
+            },
+            "data": {
+              "$ref": "#/definitions/StateResourceReadRequest"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        }
+      ]
+    },
+    "Response": {
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "CreateResourceResponse",
+          "properties": {
+            "type": {
+              "const": "CreateResourceResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/CreateResourceResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "ReadResourceResponse",
+          "properties": {
+            "type": {
+              "const": "ReadResourceResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/ReadResourceResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "UpdateResourceResponse",
+          "properties": {
+            "type": {
+              "const": "UpdateResourceResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/UpdateResourceResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "DestroyResourceResponse",
+          "properties": {
+            "type": {
+              "const": "DestroyResourceResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/DestroyResourceResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "StateResourceEventResponse",
+          "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
+          "properties": {
+            "type": {
+              "const": "StateResourceEventResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/StateResourceEventResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "title": "StateResourceReadResponse",
+          "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
+          "properties": {
+            "type": {
+              "const": "StateResourceReadResponse"
+            },
+            "data": {
+              "$ref": "#/definitions/StateResourceReadResponse"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ]
+        }
+      ]
     }
   },
   "oneOf": [
-    { "$ref": "#/definitions/CreateResourceRequest" },
-    { "$ref": "#/definitions/CreateResourceResponse" }
+    {
+      "$ref": "#/definitions/Request"
+    },
+    {
+      "$ref": "#/definitions/Response"
+    }
   ],
   "additionalProperties": false
 }

--- a/rust/nixops4-resource/resource-schema-v0.json
+++ b/rust/nixops4-resource/resource-schema-v0.json
@@ -226,64 +226,48 @@
           "type": "object",
           "title": "CreateResourceRequest",
           "properties": {
-            "type": {
-              "const": "CreateResourceRequest"
-            },
-            "data": {
+            "createResourceRequest": {
               "$ref": "#/definitions/CreateResourceRequest"
             }
           },
           "required": [
-            "type",
-            "data"
+            "createResourceRequest"
           ]
         },
         {
           "type": "object",
           "title": "ReadResourceRequest",
           "properties": {
-            "type": {
-              "const": "ReadResourceRequest"
-            },
-            "data": {
+            "readResourceRequest": {
               "$ref": "#/definitions/ReadResourceRequest"
             }
           },
           "required": [
-            "type",
-            "data"
+            "readResourceRequest"
           ]
         },
         {
           "type": "object",
           "title": "UpdateResourceRequest",
           "properties": {
-            "type": {
-              "const": "UpdateResourceRequest"
-            },
-            "data": {
+            "updateResourceRequest": {
               "$ref": "#/definitions/UpdateResourceRequest"
             }
           },
           "required": [
-            "type",
-            "data"
+            "updateResourceRequest"
           ]
         },
         {
           "type": "object",
           "title": "DestroyResourceRequest",
           "properties": {
-            "type": {
-              "const": "DestroyResourceRequest"
-            },
-            "data": {
+            "destroyResourceRequest": {
               "$ref": "#/definitions/DestroyResourceRequest"
             }
           },
           "required": [
-            "type",
-            "data"
+            "destroyResourceRequest"
           ]
         },
         {
@@ -291,16 +275,12 @@
           "title": "StateResourceEvent",
           "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
           "properties": {
-            "type": {
-              "const": "StateResourceEvent"
-            },
-            "data": {
+            "stateResourceEvent": {
               "$ref": "#/definitions/StateResourceEvent"
             }
           },
           "required": [
-            "type",
-            "data"
+            "stateResourceEvent"
           ]
         },
         {
@@ -308,16 +288,12 @@
           "title": "StateResourceReadRequest",
           "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
           "properties": {
-            "type": {
-              "const": "StateResourceReadRequest"
-            },
-            "data": {
+            "stateResourceReadRequest": {
               "$ref": "#/definitions/StateResourceReadRequest"
             }
           },
           "required": [
-            "type",
-            "data"
+            "stateResourceReadRequest"
           ]
         }
       ]
@@ -328,64 +304,48 @@
           "type": "object",
           "title": "CreateResourceResponse",
           "properties": {
-            "type": {
-              "const": "CreateResourceResponse"
-            },
-            "data": {
+            "createResourceResponse": {
               "$ref": "#/definitions/CreateResourceResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "createResourceResponse"
           ]
         },
         {
           "type": "object",
           "title": "ReadResourceResponse",
           "properties": {
-            "type": {
-              "const": "ReadResourceResponse"
-            },
-            "data": {
+            "readResourceResponse": {
               "$ref": "#/definitions/ReadResourceResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "readResourceResponse"
           ]
         },
         {
           "type": "object",
           "title": "UpdateResourceResponse",
           "properties": {
-            "type": {
-              "const": "UpdateResourceResponse"
-            },
-            "data": {
+            "updateResourceResponse": {
               "$ref": "#/definitions/UpdateResourceResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "updateResourceResponse"
           ]
         },
         {
           "type": "object",
           "title": "DestroyResourceResponse",
           "properties": {
-            "type": {
-              "const": "DestroyResourceResponse"
-            },
-            "data": {
+            "destroyResourceResponse": {
               "$ref": "#/definitions/DestroyResourceResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "destroyResourceResponse"
           ]
         },
         {
@@ -393,16 +353,12 @@
           "title": "StateResourceEventResponse",
           "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
           "properties": {
-            "type": {
-              "const": "StateResourceEventResponse"
-            },
-            "data": {
+            "stateResourceEventResponse": {
               "$ref": "#/definitions/StateResourceEventResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "stateResourceEventResponse"
           ]
         },
         {
@@ -410,16 +366,12 @@
           "title": "StateResourceReadResponse",
           "description": "<div class=\"warning\">Only implemented by state provider resources</div>",
           "properties": {
-            "type": {
-              "const": "StateResourceReadResponse"
-            },
-            "data": {
+            "stateResourceReadResponse": {
               "$ref": "#/definitions/StateResourceReadResponse"
             }
           },
           "required": [
-            "type",
-            "data"
+            "stateResourceReadResponse"
           ]
         }
       ]

--- a/rust/nixops4-resource/src/schema/v0.rs
+++ b/rust/nixops4-resource/src/schema/v0.rs
@@ -12,14 +12,15 @@ mod tests {
         assert_eq!(
             _value,
             CreateResourceRequest {
-                type_: "file".to_string(),
-                input_properties: serde_json::Map::from_iter(vec![
+                type_: ResourceType("file".to_string()),
+                input_properties: InputProperties(serde_json::Map::from_iter(vec![
                     ("path".to_string(), Value::String("pubkey.txt".to_string())),
                     (
                         "content".to_string(),
                         Value::String("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD".to_string())
                     ),
-                ]),
+                ])),
+                is_stateful: false,
             }
         );
     }

--- a/rust/nixops4-resources-local/Cargo.toml
+++ b/rust/nixops4-resources-local/Cargo.toml
@@ -15,6 +15,10 @@ nixops4-resource = { path = "../nixops4-resource" }
 anyhow = "1.0.79"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.115" }
+json-patch = "3.0.1"
+fd-lock = "4.0.2"
+tempfile = { version = "3.17.1" }
+chrono = "0.4.39"
 
 [[bin]]
 path = "src/main.rs"

--- a/rust/nixops4-resources-local/src/state.rs
+++ b/rust/nixops4-resources-local/src/state.rs
@@ -1,0 +1,490 @@
+use anyhow::{bail, Result};
+use chrono::Utc;
+use serde_json::{de::IoRead, Deserializer, StreamDeserializer};
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, Seek as _, Write},
+    path::Path,
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct StateEvent {
+    index: u64,
+    meta: StateEventMeta,
+    patch: json_patch::Patch,
+    // #[serde(flatten)]
+    // unknown_fields: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct StateEventMeta {
+    time: String,
+    #[serde(flatten)]
+    other_fields: serde_json::Value,
+}
+
+pub struct StateEventStream<'a, R: io::Read> {
+    iter: StreamDeserializer<'a, IoRead<R>, StateEvent>,
+    /// Save the validated first event for processing by our caller
+    /// (basically prepend it to the iterator)
+    first_event: Option<StateEvent>,
+}
+impl<'a, R: io::Read> StateEventStream<'a, R> {
+    pub fn open_from_reader(reader: R) -> Result<StateEventStream<'a, R>> {
+        let deserializer = Deserializer::from_reader(reader);
+        let mut iter = deserializer.into_iter();
+        let first_event = match iter.next() {
+            Some(Ok(ev @ StateEvent { index, .. })) => {
+                if index != 0 {
+                    bail!("Expected initial state event with index 0, got {}", index);
+                }
+                ev
+            }
+            Some(Err(e)) => bail!(
+                "State file invalid: error parsing initial state event: {}",
+                e
+            ),
+            None => bail!("State file invalid: no initial state event"),
+        };
+        Ok(StateEventStream {
+            iter,
+            first_event: Some(first_event),
+        })
+    }
+}
+
+// TODO: structured logging for providers
+
+/// Monitor a task which may take a long time, and write messages to the console
+/// as needed.
+/// After SILENT_INTERVAL: print activity
+/// After LOG_INTERVAL: print activity and duration
+pub struct WaitMonitor {
+    done: Arc<AtomicBool>,
+}
+impl WaitMonitor {
+    const SILENT_INTERVAL: Duration = Duration::from_millis(500);
+    const LOG_INTERVAL: Duration = Duration::from_secs(5);
+
+    pub fn new(activity: String) -> WaitMonitor {
+        Self::new_by_ref(Arc::new(AtomicBool::new(false)), activity)
+    }
+    pub fn new_by_ref(done: Arc<AtomicBool>, activity: String) -> WaitMonitor {
+        // Start thread
+        let r = WaitMonitor { done: done.clone() };
+        std::thread::spawn(|| {
+            WaitMonitor::run(done, activity);
+        });
+        r
+    }
+    fn run(done: Arc<AtomicBool>, activity: String) {
+        let start = std::time::Instant::now();
+        let mut next_log = start.checked_add(Self::SILENT_INTERVAL).unwrap();
+        loop {
+            if done.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            let now = std::time::Instant::now();
+            let next_log_interval = next_log.duration_since(now);
+            std::thread::sleep(next_log_interval);
+            if done.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            if next_log.duration_since(start) < Self::SILENT_INTERVAL {
+                eprintln!("{}", activity);
+                // Reset before adding the large scale increment
+                next_log = start;
+            } else {
+                // Current time is next_log (or very slightly past)
+                eprintln!(
+                    "{} ({} s)",
+                    activity,
+                    next_log.duration_since(start).as_secs()
+                );
+            }
+            next_log = next_log.checked_add(Self::LOG_INTERVAL).unwrap();
+        }
+    }
+    pub fn done(&self) {
+        self.done.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+impl Drop for WaitMonitor {
+    fn drop(&mut self) {
+        self.done()
+    }
+}
+
+pub struct StateHandle {
+    file: Arc<File>,
+    locking: fd_lock::RwLock<Arc<File>>,
+    expected_size: Option<u64>,
+}
+impl StateHandle {
+    pub fn open<P: AsRef<Path>>(name: P, create_new: bool) -> Result<StateHandle> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .append(true)
+            .create_new(create_new)
+            .open(name)?;
+        let file = Arc::new(file);
+        let locking = fd_lock::RwLock::new(file.clone());
+        let mut handle = StateHandle {
+            file,
+            locking,
+            expected_size: None,
+        };
+        if create_new {
+            handle.append(&[&Self::init_event()])?;
+        }
+        Ok(handle)
+    }
+    fn init_event() -> StateEvent {
+        let now = Utc::now();
+        let iso_datetime = now.to_rfc3339();
+        StateEvent {
+            index: 0,
+            meta: StateEventMeta {
+                time: iso_datetime,
+                other_fields: serde_json::json!({}),
+            },
+            patch: json_patch::Patch(vec![json_patch::PatchOperation::Add(
+                json_patch::AddOperation {
+                    path: "".parse().expect("empty path"),
+                    value: serde_json::json!({
+                        "_type": "nixopsState",
+                        "resources": {},
+                        "deployments": {},
+                    }),
+                },
+            )]),
+        }
+    }
+    fn lock_write(
+        locking: &mut fd_lock::RwLock<Arc<File>>,
+    ) -> Result<fd_lock::RwLockWriteGuard<Arc<File>>> {
+        let lock_wait_mon = WaitMonitor::new("Waiting for state file write lock".to_owned());
+        let lock = locking.write()?;
+        lock_wait_mon.done();
+        Ok(lock)
+    }
+    pub fn append(&mut self, event: &[&StateEvent]) -> Result<()> {
+        let lock_guard = Self::lock_write(&mut self.locking)?;
+        let pos = self.file.seek(io::SeekFrom::End(0))?;
+        match self.expected_size {
+            None => self.expected_size = Some(pos),
+            Some(expected_size) => {
+                if pos != expected_size {
+                    eprintln!(
+                        "Detected concurrent writing. Foreign bytes: [{}..{})",
+                        expected_size, pos
+                    );
+                    eprintln!("CRITICAL: concurrent state manipulation may require manual intervention to avoid data loss, orphaned infrastructure and cloud cost overruns");
+                }
+            }
+        }
+        let mut writer = io::BufWriter::new(self.file.clone());
+
+        for event in event {
+            // We prettify to make it more human readable. Potentially slightly
+            // harder to parse by other tools, but worth the tradeoff.
+            // In contrast, the provider protocol messages are entirely ephemeral
+            // and only ever read by developers.
+            serde_json::to_writer_pretty(&mut writer, event)?;
+            writer.write_all(b"\n")?;
+        }
+        writer.flush()?;
+
+        self.expected_size = Some(self.file.seek(io::SeekFrom::Current(0))?);
+
+        drop(lock_guard);
+        Ok(())
+    }
+}
+
+impl<'a, R: io::Read> Iterator for StateEventStream<'a, R> {
+    type Item = Result<StateEvent>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.first_event.is_some() {
+            self.first_event.take().map(Ok)
+        } else {
+            self.iter.next().map(|r| r.map_err(Into::into))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use io::{stdout, Read};
+
+    use super::*;
+
+    fn apply_state_event(state: &mut serde_json::Value, event: &StateEvent) -> Result<()> {
+        json_patch::patch(state, event.patch.0.as_slice()).map_err(Into::into)
+    }
+
+    fn apply_state_events(
+        state: &mut serde_json::Value,
+        events: impl Iterator<Item = Result<StateEvent>>,
+    ) -> Result<()> {
+        for event in events {
+            apply_state_event(state, &event?)?;
+        }
+        Ok(())
+    }
+
+    const BASIC_EXAMPLE: &str = r#"
+    {
+        "index": 0,
+        "meta": {"time":"2019-03-04T07:40:00Z"},
+        "patch": [
+            {
+                "op": "add",
+                "value": { "_type": "nixopsState", "resources": {}, "deployments": {} },
+                "path": ""
+            }
+        ]
+    }
+    {
+        "index": 1,
+        "meta": {"time":"2019-03-04T07:41:00Z"},
+        "patch": [
+            {
+                "op": "add",
+                "value": {
+                    "type": "file",
+                    "inputProperties": {
+                        "contents": "Hi there"
+                    },
+                    "outputProperties": { }
+                },
+                "path": "/resources/a"
+            }
+        ]
+    }
+"#;
+
+    #[test]
+    fn test_open_state_stream() {
+        let stream = StateEventStream::open_from_reader(BASIC_EXAMPLE.as_bytes()).unwrap();
+        let events: Vec<_> = stream.collect();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].as_ref().unwrap().index, 0);
+        assert_eq!(
+            events[0].as_ref().unwrap().meta.time,
+            "2019-03-04T07:40:00Z"
+        );
+    }
+
+    #[test]
+    fn test_resolve_state() {
+        let stream = StateEventStream::open_from_reader(BASIC_EXAMPLE.as_bytes()).unwrap();
+        let mut state = serde_json::json!({});
+        apply_state_events(&mut state, stream).unwrap();
+        assert_eq!(
+            state,
+            serde_json::json!({
+                "_type": "nixopsState",
+                "resources": {
+                    "a": {
+                        "type": "file",
+                        "inputProperties": {
+                            "contents": "Hi there"
+                        },
+                        "outputProperties": { }
+                    }
+                },
+                "deployments": { }
+            })
+        );
+    }
+
+    #[test]
+    fn test_open_state_stream_invalid_index() {
+        let input = r#"{"index":1,"meta":{"time":"2019-06-04T07:40:00Z"},"patch":[]}"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_no_index() {
+        let input = r#"{"meta":{"time":"2019-06-04T07:40:00Z"},"patch":[]}"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_invalid_json() {
+        let input = r#"{"index":0,"meta":{"time":"2019-06-04T07:40:00Z"},"patch":[]"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_empty() {
+        let input = r#""#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_empty_array() {
+        let input = r#"[]"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_no_patch() {
+        let input = r#"{"index":0,"meta":{"time":"2019-06-04T07:40:00Z"}}"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_open_state_stream_invalid_patch() {
+        let input = r#"{"index":0,"patch":[{}]}"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes());
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_invalid_second_1() {
+        let input = r#"{"index":0,"meta":{"time":"2019-06-04T07:40:00Z"},"patch":[]}
+{"meta":{"time":"2019-06-04T07:40:00Z"}}"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes()).unwrap();
+        let vec: Vec<Result<StateEvent>> = stream.collect();
+        assert!(vec[1].is_err());
+    }
+
+    #[test]
+    fn test_invalid_second_2() {
+        let input = r#"{"index":0,"meta":{"time":"2019-06-04T07:40:00Z"},"patch":[]}
+{"#;
+        let stream = StateEventStream::open_from_reader(input.as_bytes()).unwrap();
+        let vec: Vec<Result<StateEvent>> = stream.collect();
+        assert!(vec[1].is_err());
+    }
+
+    #[test]
+    #[ignore] // Slow test, no assertions, temporary code
+    fn test_wait_monitor() {
+        let monitor = WaitMonitor::new("Testing...".to_owned());
+        std::thread::sleep(Duration::from_secs(25));
+        monitor.done();
+    }
+
+    #[test]
+    fn test_state_file_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut state = StateHandle::open(&path, true).unwrap();
+        state
+            .append(&[&StateEvent {
+                index: 0,
+                meta: StateEventMeta {
+                    time: "2019-03-04T07:40:00Z".to_owned(),
+                    other_fields: serde_json::json!({}),
+                },
+                patch: json_patch::Patch(vec![json_patch::PatchOperation::Add(
+                    json_patch::AddOperation {
+                        path: "".parse().expect("empty path"),
+                        value: serde_json::json!({
+                            "_type": "nixopsState",
+                            "resources": {},
+                            "deployments": {},
+                        }),
+                    },
+                )]),
+            }])
+            .unwrap();
+        state
+            .append(&[&StateEvent {
+                index: 1,
+                meta: StateEventMeta {
+                    time: "2019-03-04T07:41:00Z".to_owned(),
+                    other_fields: serde_json::json!({}),
+                },
+                patch: json_patch::Patch(vec![json_patch::PatchOperation::Add(
+                    json_patch::AddOperation {
+                        path: "/resources/a".parse().expect("empty path"),
+                        value: serde_json::json!({
+                            "type": "file",
+                            "inputProperties": {
+                                "contents": "Hi there",
+                            },
+                            "outputProperties": {},
+                        }),
+                    },
+                )]),
+            }])
+            .unwrap();
+        // read and print
+        // let mut file = File::open(&path).unwrap();
+        // let mut buf = Vec::new();
+        // file.read_to_end(&mut buf).unwrap();
+        // stdout().write_all(&buf).unwrap();
+    }
+
+    #[test]
+    #[ignore] // Manual test, no assertions
+    fn test_state_file_write_multiple_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut state = StateHandle::open(&path, true).unwrap();
+        let mut state2 = StateHandle::open(&path, false).unwrap();
+
+        state2
+            .append(&[&StateEvent {
+                index: 1,
+                meta: StateEventMeta {
+                    time: "2019-03-04T07:41:00Z".to_owned(),
+                    other_fields: serde_json::json!({}),
+                },
+                patch: json_patch::Patch(vec![json_patch::PatchOperation::Add(
+                    json_patch::AddOperation {
+                        path: "/resources/a".parse().expect("empty path"),
+                        value: serde_json::json!({
+                            "type": "file",
+                            "inputProperties": {
+                                "contents": "Hi there",
+                            },
+                            "outputProperties": {},
+                        }),
+                    },
+                )]),
+            }])
+            .unwrap();
+
+        state
+            .append(&[&StateEvent {
+                index: 1,
+                meta: StateEventMeta {
+                    time: "2019-03-04T07:41:00Z".to_owned(),
+                    other_fields: serde_json::json!({}),
+                },
+                patch: json_patch::Patch(vec![json_patch::PatchOperation::Add(
+                    json_patch::AddOperation {
+                        path: "/resources/a".parse().expect("empty path"),
+                        value: serde_json::json!({
+                            "type": "file",
+                            "inputProperties": {
+                                "contents": "Hi there",
+                            },
+                            "outputProperties": {},
+                        }),
+                    },
+                )]),
+            }])
+            .unwrap();
+        // read and print
+        let mut file = File::open(&path).unwrap();
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        stdout().write_all(&buf).unwrap();
+    }
+}

--- a/rust/nixops4/Cargo.toml
+++ b/rust/nixops4/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.44.2", features = ["io-std", "io-util", "process", "rt", 
 lazy_static = "1.5.0"
 pubsub-rs = "0.1.1"
 async-trait = "0.1.88"
+json-patch = "4.0.0"
 
 [dependencies.ratatui]
 version = "0.29.0"

--- a/rust/nixops4/Cargo.toml
+++ b/rust/nixops4/Cargo.toml
@@ -30,6 +30,10 @@ nix = "0.29.0"
 crossterm = "0.28.1"
 ansi-parser = "0.9.1"
 ctrlc = "3.4.5"
+tokio = { version = "1.44.2", features = ["io-std", "io-util", "process", "rt", "sync"] }
+lazy_static = "1.5.0"
+pubsub-rs = "0.1.1"
+async-trait = "0.1.88"
 
 [dependencies.ratatui]
 version = "0.29.0"

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -193,12 +193,12 @@ pub(crate) fn apply(
                                             let provider_argv =
                                                 provider::parse_provider(&provider_info.provider)?;
                                             // Run the provider
-                                            let provider = ResourceProviderClient::new(
+                                            let mut provider = ResourceProviderClient::new(
                                                 ResourceProviderConfig {
                                                     provider_executable: provider_argv.executable,
                                                     provider_args: provider_argv.args,
                                                 },
-                                            );
+                                            )?;
                                             let outputs = provider
                                                 .create(
                                                     provider_info.resource_type.as_str(),

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -434,11 +434,6 @@ impl bob::BobClosure for ApplyContext {
                                 .with_context(|| {
                                     format!("Failed to create stateless resource {}", name)
                                 })?;
-                            let r = provider.close_wait().await?;
-                            if !r.success() {
-                                // We did get outputs, so this seems unlikely
-                                bail!("Provider exited unexpectedly: {}", r);
-                            }
                             outputs
                         }
                         Some(state) => match state.past.deployment.resources.get(&name) {
@@ -493,10 +488,6 @@ impl bob::BobClosure for ApplyContext {
                                 state
                                     .resource_event(&name, "create", None, &current_resource)
                                     .await?;
-                                // let r = provider.close_wait().await?;
-                                // if !r.success() {
-                                //     bail!("Provider exited unexpectedly: {}", r);
-                                // }
                                 outputs
                             }
                         },

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -430,8 +430,10 @@ impl bob::BobClosure for ApplyContext {
                         None => {
                             let outputs = provider
                                 .create(provider_info.resource_type.as_str(), &inputs)
-                                .await?;
-                            // .with_context(|| format!("Failed to create resource {}", name))?;
+                                .await
+                                .with_context(|| {
+                                    format!("Failed to create stateless resource {}", name)
+                                })?;
                             let r = provider.close_wait().await?;
                             if !r.success() {
                                 // We did get outputs, so this seems unlikely

--- a/rust/nixops4/src/bob.rs
+++ b/rust/nixops4/src/bob.rs
@@ -1,0 +1,380 @@
+//! Bob is a ~~builder.~~ scheduling system that provides async task scheduling with cycle detection.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+};
+use tokio::sync::Mutex;
+
+/// A lazy thunk that runs a future only once and caches its result.
+pub struct Thunk<T> {
+    // Once forced, value holds Some(result).
+    value: Mutex<Option<Arc<T>>>,
+    // The future is kept until evaluation; then we replace it with None.
+    future: Mutex<Option<Pin<Box<dyn Future<Output = T> + Send>>>>,
+}
+
+impl<T> Thunk<T> {
+    pub fn new<F>(future: F) -> Arc<Self>
+    where
+        F: Future<Output = T> + 'static + Send,
+    {
+        Arc::new(Thunk {
+            value: Mutex::new(None),
+            future: Mutex::new(Some(Box::pin(future))),
+        })
+    }
+
+    /// Force the thunk. The inner future is polled to completion only on the first call.
+    /// Subsequent calls return the cached value.
+    pub async fn force(self: Arc<Self>) -> Arc<T> {
+        // Check cache first.
+        if let Some(val) = self.value.lock().await.as_ref() {
+            return val.clone();
+        }
+
+        // Take the future out – the future must be polled exactly once.
+        let fut = self.future.lock().await.take();
+        match fut {
+            // We got the lock first and it's our responsibility to await the future.
+            Some(fut) => {
+                let mut l = self.value.lock().await;
+                let r = Arc::new(fut.await);
+                l.replace(r.clone());
+                r
+            }
+            // The future should have been forced by another thread.
+            None => {
+                // Get it from the cache
+                let l = self.value.lock().await;
+                let val = l.as_ref();
+                match val {
+                    Some(val) => return val.clone(),
+                    None => panic!(
+                        "Thunk was not forced successfully and future is gone. Can't continue."
+                    ),
+                }
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait BobClosure {
+    type Output: Send + Sync;
+    type Key: Clone + Ord + std::fmt::Display + Send;
+
+    async fn work(&self, context: BobContext<Self>, key: Self::Key) -> Self::Output;
+}
+
+pub struct BobTask<Work: BobClosure + ?Sized> {
+    // key: Work::Key,
+    result: Arc<Thunk<Work::Output>>,
+    dependencies: Vec<Work::Key>,
+}
+
+struct InnerState<Work: BobClosure + ?Sized> {
+    tasks: BTreeMap<Work::Key, BobTask<Work>>,
+}
+impl<Work: BobClosure + ?Sized> InnerState<Work> {
+    fn new() -> Self {
+        InnerState {
+            tasks: BTreeMap::new(),
+        }
+    }
+}
+
+pub struct BobState<Work: BobClosure + ?Sized> {
+    state: Arc<Mutex<InnerState<Work>>>,
+    closure: Arc<Box<Work>>,
+}
+impl<Work: BobClosure + Send + Sync + 'static> BobState<Work> {
+    pub fn new_arc(closure: Arc<Box<Work>>) -> Arc<Self> {
+        Arc::new(BobState {
+            state: Arc::new(Mutex::new(InnerState::new())),
+            closure,
+        })
+    }
+    #[cfg(test)]
+    pub fn new(closure: Work) -> Arc<Self> {
+        BobState::new_arc(Arc::new(Box::new(closure)))
+    }
+
+    pub async fn create(self: &Arc<Self>, key: Work::Key) -> Arc<Thunk<Work::Output>> {
+        // Look up the task
+        let mut state = self.state.lock().await;
+        let task = state.tasks.get(&key);
+        if let Some(task) = task {
+            // If the task is already running, return the result
+            return task.result.clone();
+        }
+        // If the task is not found, create a new one
+        let result = {
+            let context = BobContext {
+                bob: self.clone(),
+                key: key.clone(),
+            };
+            let closure = self.closure.clone();
+            let key2 = key.clone();
+            Thunk::new(async move { closure.work(context, key2).await })
+        };
+        let task = BobTask {
+            // key: key.clone(),
+            result,
+            dependencies: Vec::new(),
+        };
+        state.tasks.insert(key.clone(), task);
+        state.tasks.get(&key).unwrap().result.clone()
+    }
+
+    pub async fn run(self: &Arc<Self>, key: Work::Key) -> Arc<Work::Output> {
+        // Look up the task
+        let thunk = self.create(key).await;
+        // ^ closed the lock on tasks
+        thunk.force().await
+    }
+}
+
+pub struct BobContext<Work: BobClosure + ?Sized> {
+    // tasks: Arc<Mutex<BTreeMap<Work::Key, BobTask<Work>>>>,
+    bob: Arc<BobState<Work>>,
+    key: Work::Key,
+}
+impl<Work: BobClosure + ?Sized> Clone for BobContext<Work> {
+    fn clone(&self) -> Self {
+        BobContext {
+            bob: self.bob.clone(),
+            key: self.key.clone(),
+        }
+    }
+}
+impl<'a, Work: BobClosure + Send + Sync + 'static> BobContext<Work> {
+    pub fn closure(&self) -> &Work {
+        &self.bob.closure
+    }
+    async fn add_dependency(&self, key: Work::Key) -> Result<(), Cycle<Work::Key>> {
+        let mut state = self.bob.state.lock().await;
+
+        let task = state.tasks.get(&self.key);
+
+        if let Some(task) = task {
+            if task.dependencies.contains(&key) {
+                // Already a dependency; nothing to do
+                return Ok(());
+            }
+
+            if let Some(mut path) = find_path_to(
+                &mut BTreeSet::new(),
+                &state.tasks,
+                &self.key,
+                &[key.clone()],
+            ) {
+                path.reverse();
+                Err(Cycle { path })?;
+            }
+
+            let task = state.tasks.get_mut(&self.key).unwrap();
+
+            task.dependencies.push(key);
+            Ok(())
+        } else {
+            panic!("Bob: current task disappeared");
+        }
+    }
+
+    pub async fn spawn(
+        &self,
+        key: Work::Key,
+    ) -> Result<Arc<Thunk<<Work as BobClosure>::Output>>, Cycle<Work::Key>> {
+        let bob_clone = self.bob.clone();
+        let this = self.clone();
+
+        this.add_dependency(key.clone()).await?;
+        let r = bob_clone.create(key).await;
+        let r_2 = r.clone();
+        tokio::spawn(r_2.force());
+        Ok(r)
+    }
+
+    pub fn require(
+        &self,
+        key: Work::Key,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<Work::Output>, Cycle<Work::Key>>> + Send + '_>>
+    where
+        Work: 'static,
+        Work::Output: Sync + Send,
+        Work::Key: Sync + Send,
+    {
+        let bob_clone = self.bob.clone();
+        let this = self.clone();
+        Box::pin(async move {
+            this.add_dependency(key.clone()).await?;
+            let r = bob_clone.run(key).await;
+            Ok(r)
+        })
+    }
+}
+
+// Naive cycle detection
+fn find_path_to<Work: BobClosure>(
+    seen: &mut BTreeSet<<Work as BobClosure>::Key>,
+    tasks: &BTreeMap<Work::Key, BobTask<Work>>,
+    needle: &<Work as BobClosure>::Key,
+    outgoing: &[<Work as BobClosure>::Key],
+) -> Option<Vec<Work::Key>> {
+    // First check if the key is in the dependencies
+    if outgoing.contains(needle) {
+        return Some(vec![needle.clone()]);
+    }
+    // Maybe a longer path exists
+    for edge in outgoing {
+        if seen.contains(edge) {
+            continue;
+        }
+        seen.insert(edge.clone());
+
+        let node = tasks.get(edge);
+        if let Some(node) = node {
+            if let Some(mut path) = find_path_to(seen, tasks, needle, node.dependencies.as_slice())
+            {
+                path.push(edge.clone());
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+pub struct Cycle<Key> {
+    path: Vec<Key>,
+}
+impl<Key: Clone> Clone for Cycle<Key> {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+        }
+    }
+}
+impl<Key> Cycle<Key> {
+    /// The path that forms a cycle, such that the first element depended on the second element, and so forth.
+    /// The last element depends on the first element, but the first element is not repeated in `path()`.
+    pub fn path(&self) -> &Vec<Key> {
+        &self.path
+    }
+    fn check(&self) {
+        assert!(self.path.len() > 0, "Cycle must have at least one element");
+    }
+}
+impl<Key: std::fmt::Display> std::fmt::Display for Cycle<Key> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.check();
+        let mut s = String::new();
+        self.path().iter().for_each(|k| {
+            s.push_str(&format!("{} -> \n", k));
+        });
+        s.push_str(&format!("{}", self.path.first().unwrap()));
+        write!(f, "{}", s)
+    }
+}
+impl<Key: std::fmt::Debug> std::fmt::Debug for Cycle<Key> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.check();
+        let mut s = String::new();
+        self.path().iter().for_each(|k| {
+            s.push_str(&format!("{:?} -> ", k));
+        });
+        s.push_str(&format!("{:?}", self.path.first().unwrap()));
+        write!(f, "{}", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+
+    // Fibonacci function has empty closure, so the BobClosure is also empty.
+    struct Fibonacci {}
+    #[async_trait]
+    impl BobClosure for Fibonacci {
+        type Output = u128;
+
+        type Key = u64;
+
+        async fn work(&self, context: BobContext<Self>, key: Self::Key) -> Self::Output {
+            match key {
+                0 => 0,
+                1 => 1,
+                _ => {
+                    let a = context.require(key - 1).await.unwrap();
+                    let b = context.require(key - 2).await.unwrap();
+                    *a + *b
+                }
+            }
+        }
+    }
+
+    lazy_static::lazy_static! {
+        static ref RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+    }
+
+    fn rt_block_on<Fut: Future>(fut: Fut) -> Fut::Output {
+        RUNTIME.block_on(fut)
+    }
+
+    #[test]
+    fn test_fibonacci() {
+        let bob = BobState::new(Fibonacci {});
+        assert_eq!(*rt_block_on(bob.run(0)), 0);
+        assert_eq!(*rt_block_on(bob.run(1)), 1);
+        assert_eq!(*rt_block_on(bob.run(2)), 1);
+        assert_eq!(*rt_block_on(bob.run(3)), 2);
+        assert_eq!(*rt_block_on(bob.run(4)), 3);
+        assert_eq!(*rt_block_on(bob.run(5)), 5);
+
+        // assert_eq!(*rt_block_on(bob.run(20)), 6765);
+        // assert_eq!(*rt_block_on(bob.run(30)), 832040);
+        // assert_eq!(*rt_block_on(bob.run(40)), 102334155);
+        // assert_eq!(*rt_block_on(bob.run(90)), 2880067194370816120u128);
+
+        // u128 max:                           340282366920938463463374607431768211455u128
+        assert_eq!(
+            *rt_block_on(bob.run(186)),
+            332825110087067562321196029789634457848u128
+        );
+    }
+
+    struct Cyclic {
+        modulo: u64,
+    }
+    #[async_trait]
+    impl BobClosure for Cyclic {
+        type Output = Result<u64, Cycle<u64>>;
+
+        type Key = u64;
+
+        async fn work(&self, context: BobContext<Self>, key: Self::Key) -> Self::Output {
+            let r = context.require((key + 1) % self.modulo).await?;
+            let r = r.as_ref();
+            match r {
+                Ok(v) => Ok(*v),
+                Err(cycle) => Err(cycle.clone()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_cyclic() {
+        let bob = BobState::new(Cyclic { modulo: 10 });
+        let r = rt_block_on(bob.run(0));
+        let e = r.as_ref().clone().unwrap_err();
+        let expected: Vec<u64> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        assert_eq!(e.path(), &expected);
+    }
+}

--- a/rust/nixops4/src/eval_client.rs
+++ b/rust/nixops4/src/eval_client.rs
@@ -1,14 +1,14 @@
-use std::{
-    collections::HashMap,
-    io::{BufRead, Write},
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use nixops4_core::eval_api::{self, EvalRequest, Id, Ids, MessageType, QueryRequest};
+use tokio::sync::mpsc::{channel, Sender};
+use tokio::sync::Mutex;
+use tokio::{
+    io::{AsyncBufReadExt as _, AsyncWriteExt as _},
     process::ChildStdout,
 };
-
-use anyhow::{Context, Result};
-use nixops4_core::eval_api::{
-    self, DeploymentType, EvalRequest, EvalResponse, FlakeType, Id, IdNum, Ids, MessageType,
-    QueryRequest,
-};
+use tracing::debug;
 
 #[derive(Clone)]
 pub(crate) struct Options {
@@ -17,26 +17,26 @@ pub(crate) struct Options {
     pub(crate) flake_input_overrides: Vec<(String, String)>,
 }
 
-pub struct EvalClient {
-    options: Options,
-
-    response_bufreader: std::io::BufReader<ChildStdout>,
-    command_handle: std::process::ChildStdin,
-    tracing_event_receiver: tracing_tunnel::TracingEventReceiver,
-
+#[derive(Clone)]
+pub struct EvalSender {
+    sender: Arc<Mutex<Option<Sender<EvalRequest>>>>,
     ids: Ids,
-    deployments: HashMap<Id<FlakeType>, Vec<String>>,
-    resources: HashMap<Id<DeploymentType>, Vec<String>>,
-    errors: HashMap<IdNum, String>,
 }
-impl EvalClient {
-    pub fn with<T>(options: &Options, f: impl FnOnce(EvalClient) -> Result<T>) -> Result<T> {
+
+type EvalReceiver = tokio::sync::mpsc::Receiver<eval_api::EvalResponse>;
+
+impl EvalSender {
+    pub async fn with<T, F, Fut>(options: &Options, f: F) -> Result<T>
+    where
+        F: FnOnce(EvalSender, EvalReceiver) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
         let exe = std::env::var("_NIXOPS4_EVAL").unwrap_or("nixops4-eval".to_string());
         let mut nix_config = std::env::var("NIX_CONFIG").unwrap_or("".to_string());
         if options.show_trace {
             nix_config.push_str("\nshow-trace = true\n");
         }
-        let mut process = std::process::Command::new(exe)
+        let mut process = tokio::process::Command::new(exe)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .arg("<subprocess>")
@@ -44,129 +44,157 @@ impl EvalClient {
             .spawn()
             .context("while starting the nixops4 evaluator process")?;
 
-        if options.verbose {
-            eprintln!("started nixops4-eval process: {}", process.id());
-        }
-
         let r;
         {
-            let c: EvalClient = EvalClient {
-                options: options.clone(),
-                response_bufreader: std::io::BufReader::new(process.stdout.take().unwrap()),
-                command_handle: process.stdin.take().unwrap(),
-                tracing_event_receiver: tracing_tunnel::TracingEventReceiver::default(),
-                ids: Ids::new(),
-                deployments: HashMap::new(),
-                resources: HashMap::new(),
-                errors: HashMap::new(),
+            let response_bufreader = tokio::io::BufReader::new(process.stdout.take().unwrap());
+            let command_handle = process.stdin.take().unwrap();
+            let tracing_event_receiver = tracing_tunnel::TracingEventReceiver::default();
+            let ids = Ids::new();
+            let verbose = options.verbose;
+
+            let (command_sender, command_receiver) = channel::<EvalRequest>(128);
+
+            let writer = tokio::spawn(forward_eval_commands(
+                command_handle,
+                verbose,
+                command_receiver,
+            ));
+
+            let (response_sender, response_receiver) = channel::<eval_api::EvalResponse>(128);
+
+            let reader = tokio::spawn(forward_eval_responses(
+                verbose,
+                response_sender,
+                response_bufreader,
+                tracing_event_receiver,
+            ));
+
+            let eval_sender = EvalSender {
+                sender: Arc::new(Mutex::new(Some(command_sender))),
+                ids: ids.clone(),
             };
 
-            r = f(c)
+            r = f(eval_sender, response_receiver).await;
+
+            writer.await??;
+            reader.await??;
         }
         // Wait for the process to exit, giving it a chance to flush its output
         // TODO (tokio): add timeout
-        process.wait()?;
+        process.wait().await?;
 
         r
     }
-    pub fn send(&mut self, request: &EvalRequest) -> Result<()> {
-        let json = eval_api::eval_request_to_json(request)?;
-        if self.options.verbose {
-            eprintln!("\x1b[35msending: {}\x1b[0m", json);
-        }
-        self.command_handle.write_all(json.as_bytes())?;
-        self.command_handle.write_all(b"\n")?;
-        self.command_handle.flush()?;
-        Ok(())
-    }
-    pub fn query<P, R>(
-        &mut self,
-        f: impl FnOnce(QueryRequest<P, R>) -> EvalRequest,
-        payload: P,
-    ) -> Result<Id<MessageType>> {
-        let msg_id = self.next_id();
-        self.send(&f(QueryRequest::new(msg_id, payload)))?;
-        Ok(msg_id)
-    }
-    fn receive(&mut self) -> Result<eval_api::EvalResponse> {
-        let mut line = String::new();
-        let n = self.response_bufreader.read_line(&mut line);
-        match n {
-            Err(e) => {
-                Err(e).context("error reading from nixops4-eval process stdout")?;
-            }
-            Ok(0) => {
-                Err(anyhow::anyhow!("nixops4-eval process closed its stdout"))?;
-            }
-            Ok(_) => {}
-        }
-        if self.options.verbose {
-            eprintln!("\x1b[32mreceived: {}\x1b[0m", line.trim_end());
-        }
-        let response = eval_api::eval_response_from_json(line.as_str())?;
-        Ok(response)
-    }
-    pub fn receive_until<T>(
-        &mut self,
-        cond: impl Fn(&mut EvalClient, &EvalResponse) -> Result<Option<T>>,
-    ) -> Result<T> {
-        loop {
-            let response = self.receive()?;
-            self.handle_response(&response)?;
-            let r = cond(self, &response)?;
-            match r {
-                Some(r) => return Ok(r),
-                None => continue,
-            }
-        }
-    }
 
-    pub fn next_id<T>(&mut self) -> Id<T> {
+    pub fn next_id<T>(&self) -> eval_api::Id<T> {
         self.ids.next()
     }
 
-    pub fn get_error<T>(&self, id: Id<T>) -> Option<&String> {
-        self.errors.get(&id.num())
-    }
-
-    pub fn check_error<T>(&self, id: Id<T>) -> Result<()> {
-        if let Some(e) = self.get_error(id) {
-            Err(anyhow::anyhow!("evaluation: {}", e))
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn get_deployments(&self, id: Id<FlakeType>) -> Option<&Vec<String>> {
-        self.deployments.get(&id)
-    }
-
-    pub fn get_resources(&self, id: Id<DeploymentType>) -> Option<&Vec<String>> {
-        self.resources.get(&id)
-    }
-
-    fn handle_response(&mut self, response: &eval_api::EvalResponse) -> Result<()> {
-        match response {
-            eval_api::EvalResponse::Error(id, error) => {
-                self.errors.insert(id.num(), error.clone());
+    pub async fn send(&self, request: &EvalRequest) -> Result<()> {
+        let mut sender = self.sender.lock().await;
+        match sender.as_mut() {
+            Some(sender) => {
+                if let Err(e) = sender.send(request.clone()).await {
+                    bail!("error sending eval request: {}", e);
+                }
+                Ok(())
             }
-            eval_api::EvalResponse::QueryResponse(_id, value) => match value {
-                eval_api::QueryResponseValue::ListDeployments((flake_id, deployments)) => {
-                    self.deployments.insert(*flake_id, deployments.clone());
-                }
-                eval_api::QueryResponseValue::ListResources((deployment_id, resources)) => {
-                    self.resources.insert(*deployment_id, resources.clone());
-                }
-                _ => {}
-            },
-            eval_api::EvalResponse::TracingEvent(v) => {
-                let event =
-                    serde_json::from_value(v.clone()).context("while parsing tracing event")?;
-                if let Err(e) = self.tracing_event_receiver.try_receive(event) {
-                    eprintln!("error handling tracing event: {}", e);
-                }
+            None => {
+                bail!("refusing to send eval request as eval process is exiting");
             }
         }
-        Ok(())
     }
+
+    pub async fn close(&self) {
+        let mut sender = self.sender.lock().await;
+        *sender = None;
+    }
+
+    pub async fn query<P, R>(
+        &self,
+        id: Id<MessageType>,
+        f: impl FnOnce(QueryRequest<P, R>) -> EvalRequest,
+        payload: P,
+    ) -> Result<()> {
+        self.send(&f(QueryRequest::new(id, payload))).await
+    }
+}
+
+async fn forward_eval_responses(
+    verbose: bool,
+    response_sender: Sender<eval_api::EvalResponse>,
+    response_bufreader: tokio::io::BufReader<ChildStdout>,
+    mut tracing_event_receiver: tracing_tunnel::TracingEventReceiver,
+) -> Result<()> {
+    let mut lines = response_bufreader.lines();
+    loop {
+        let line_result = lines.next_line().await;
+        match line_result {
+            Ok(Some(line)) => {
+                if let Ok(response) = eval_api::eval_response_from_json(line.as_str()) {
+                    if verbose {
+                        eprintln!("\x1b[32mreceived: {}\x1b[0m", line.trim_end());
+                    }
+
+                    if let eval_api::EvalResponse::TracingEvent(v) = &response {
+                        let event = serde_json::from_value(v.clone())
+                            .context("while parsing tracing event")?;
+                        if let Err(e) = tracing_event_receiver.try_receive(event) {
+                            eprintln!("error handling tracing event: {}", e);
+                        }
+                    } else if let Err(e) = response_sender.send(response).await {
+                        // Presumably the main program has produced an error, or has terminated correctly, and we can just ignore any extra messages?
+                        debug!("error sending response to channel: {}", e);
+                        // continue processing tracing events
+                    }
+                } else {
+                    bail!("error parsing response: {}", line);
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                bail!("error reading from nixops4-eval process stdout: {}", e);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn forward_eval_commands(
+    mut command_handle: tokio::process::ChildStdin,
+    verbose: bool,
+    mut command_receiver: tokio::sync::mpsc::Receiver<EvalRequest>,
+) -> Result<()> {
+    loop {
+        let request = command_receiver.recv().await;
+        match request {
+            Some(request) => {
+                let r = write_eval_request(verbose, &mut command_handle, &request).await;
+                match r {
+                    Ok(()) => {}
+                    Err(e) => {
+                        eprintln!("error writing to nixops4-eval process stdin: {}", e);
+                        break;
+                    }
+                }
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+async fn write_eval_request(
+    verbose: bool,
+    command_handle: &mut tokio::process::ChildStdin,
+    request: &EvalRequest,
+) -> Result<()> {
+    let json = eval_api::eval_request_to_json(&request)?;
+    if verbose {
+        eprintln!("\x1b[35msending: {}\x1b[0m", json);
+    }
+    command_handle.write_all(json.as_bytes()).await?;
+    command_handle.write_all(b"\n").await?;
+    command_handle.flush().await?;
+    Ok(())
 }

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -3,6 +3,7 @@ mod eval_client;
 mod interrupt;
 mod logging;
 mod provider;
+mod state;
 
 use anyhow::Result;
 use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -1,28 +1,38 @@
 mod apply;
+mod bob;
 mod eval_client;
 mod interrupt;
 mod logging;
 mod provider;
 mod state;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
-use eval_client::EvalClient;
 use interrupt::{set_up_process_interrupt_handler, InterruptState};
-use nixops4_core::eval_api::{AssignRequest, EvalRequest, FlakeRequest, FlakeType, Id};
+use nixops4_core::eval_api::{
+    AssignRequest, EvalRequest, EvalResponse, FlakeRequest, QueryResponseValue,
+};
 use std::process::exit;
 
 fn main() {
     let interrupt_state = set_up_process_interrupt_handler();
-    let args = Args::parse();
-    handle_result(run_args(&interrupt_state, args));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+    rt.block_on(async {
+        let args = Args::parse();
+        handle_result(run_args(&interrupt_state, args).await);
+    });
 }
 
-fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
+async fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
     match &args.command {
         Commands::Apply(subargs) => {
             let mut logging = set_up_logging(interrupt_state, &args)?;
-            apply::apply(interrupt_state, &args.options, subargs)?;
+            // apply::apply(interrupt_state, &args.options, subargs)?;
+
+            apply::apply_async(interrupt_state, &args.options, subargs).await?;
             logging.tear_down()?;
             Ok(())
         }
@@ -30,7 +40,7 @@ fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
             match sub {
                 Deployments::List {} => {
                     let mut logging = set_up_logging(interrupt_state, &args)?;
-                    let deployments = deployments_list(&args.options)?;
+                    let deployments = deployments_list(&args.options).await?;
                     logging.tear_down()?;
                     for d in deployments {
                         println!("{}", d);
@@ -108,41 +118,54 @@ fn to_eval_options(options: &Options) -> eval_client::Options {
     }
 }
 
-/// Convenience function that sets up an evaluator with a flake, asynchronously with regard to evaluation.
-fn with_flake<T>(
-    options: &Options,
-    f: impl FnOnce(EvalClient, Id<FlakeType>) -> Result<T>,
-) -> Result<T> {
-    let options = to_eval_options(options);
-    EvalClient::with(&options, |mut c| {
-        let flake_id = c.next_id();
+// TODO: clean up, unify with apply infrastructure
+async fn deployments_list(options: &Options) -> Result<Vec<String>> {
+    let eval_options = to_eval_options(options);
+    let eval_options_2 = eval_options.clone();
+    eval_client::EvalSender::with(&eval_options, |s, mut r| async move {
+        let flake_id = s.next_id();
         // TODO: use better file path string type more
         let cwd = std::env::current_dir()
             .unwrap()
             .to_string_lossy()
             .to_string();
-        c.send(&EvalRequest::LoadFlake(AssignRequest {
+        s.send(&EvalRequest::LoadFlake(AssignRequest {
             assign_to: flake_id,
             payload: FlakeRequest {
                 abspath: cwd,
-                input_overrides: options.flake_input_overrides.clone(),
+                input_overrides: eval_options_2.flake_input_overrides.clone(),
             },
-        }))?;
-        f(c, flake_id)
-    })
-}
+        }))
+        .await?;
 
-fn deployments_list(options: &Options) -> Result<Vec<String>> {
-    with_flake(options, |mut c, flake_id| {
-        let deployments_id = c.query(EvalRequest::ListDeployments, flake_id)?;
-        let deployments = c.receive_until(|client, _resp| {
-            client.check_error(flake_id)?;
-            client.check_error(deployments_id)?;
-            let x = client.get_deployments(flake_id);
-            Ok(x.cloned())
-        })?;
+        s.query(s.next_id(), &EvalRequest::ListDeployments, flake_id)
+            .await?;
+
+        let deployments = loop {
+            match r.recv().await {
+                None => {
+                    bail!("Error: no response from evaluator");
+                }
+                Some(EvalResponse::Error(_id, e)) => {
+                    bail!("Error: {}", e);
+                }
+                Some(EvalResponse::QueryResponse(
+                    _,
+                    QueryResponseValue::ListDeployments((_id, deployments)),
+                )) => {
+                    break deployments.iter().cloned().collect::<Vec<_>>();
+                }
+                Some(EvalResponse::QueryResponse(_, _)) => {
+                    // Ignore other query responses
+                }
+                Some(EvalResponse::TracingEvent(_value)) => {
+                    // Already handled in an EvalSender::with thread => ignore
+                }
+            }
+        };
         Ok(deployments)
     })
+    .await
 }
 
 fn handle_result(r: Result<()>) {

--- a/rust/nixops4/src/state.rs
+++ b/rust/nixops4/src/state.rs
@@ -1,0 +1,46 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde::Deserializer;
+
+/// The root of a state file.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub struct State {
+    #[serde(flatten)]
+    deployment: DeploymentState,
+
+    #[serde(deserialize_with = "type_is_nixops_state")]
+    _type: String,
+}
+
+fn type_is_nixops_state<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    if s == "nixopsState" {
+        Ok(s)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "unexpected _type in nixops state: expected 'nixopsState', got '{}'",
+            s
+        )))
+    }
+}
+
+/// The state of a set of resources
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub struct DeploymentState {
+    resources: BTreeMap<String, ResourceState>,
+    /// State of resources in nested deployments
+    deployments: BTreeMap<String, DeploymentState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub struct ResourceState {
+    /// The type of the resource
+    #[serde(rename = "type")]
+    type_: String,
+    /// The properties of the resource
+    properties: serde_json::Value,
+}

--- a/rust/nixops4/src/state.rs
+++ b/rust/nixops4/src/state.rs
@@ -1,13 +1,24 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
+use anyhow::Context as _;
+use anyhow::Result;
+use nixops4_core::eval_api::ResourceProviderInfo;
+use nixops4_resource::schema::v0;
+use nixops4_resource::schema::v0::ExtantResource;
+use nixops4_resource_runner::ResourceProviderClient;
 use serde::Deserialize;
 use serde::Deserializer;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::provider;
 
 /// The root of a state file.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 pub struct State {
     #[serde(flatten)]
-    deployment: DeploymentState,
+    pub deployment: DeploymentState,
 
     #[serde(deserialize_with = "type_is_nixops_state")]
     _type: String,
@@ -31,16 +42,109 @@ where
 /// The state of a set of resources
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 pub struct DeploymentState {
-    resources: BTreeMap<String, ResourceState>,
+    pub resources: BTreeMap<String, ResourceState>,
     /// State of resources in nested deployments
-    deployments: BTreeMap<String, DeploymentState>,
+    pub deployments: BTreeMap<String, DeploymentState>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceState {
     /// The type of the resource
     #[serde(rename = "type")]
-    type_: String,
-    /// The properties of the resource
-    properties: serde_json::Value,
+    pub type_: String,
+    /// The input properties of the resource
+    pub input_properties: serde_json::Map<String, serde_json::Value>,
+    /// The output properties of the resource
+    pub output_properties: serde_json::Map<String, serde_json::Value>,
+}
+
+pub struct StateHandle {
+    pub past: State,
+    pub state_provider_resource: v0::ExtantResource,
+    pub state_provider: Arc<Mutex<ResourceProviderClient>>,
+}
+impl StateHandle {
+    pub async fn open(
+        provider_info: &ResourceProviderInfo,
+        resource: &ExtantResource,
+    ) -> Result<Arc<StateHandle>> {
+        let provider_argv = provider::parse_provider(&provider_info.provider)?;
+        // Run the provider
+        let mut provider =
+            ResourceProviderClient::new(nixops4_resource_runner::ResourceProviderConfig {
+                provider_executable: provider_argv.executable,
+                provider_args: provider_argv.args,
+            })
+            .await?;
+
+        let state = provider.state_read(resource.clone()).await?;
+        // Awkwardly construct a JSON object from the BTreeMap
+        let state = serde_json::to_value(&state)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize state: {}", e))?;
+        let state = serde_json::from_value::<State>(state)
+            .map_err(|e| anyhow::anyhow!("Failed to parse state: {}", e))?;
+
+        Ok(Arc::new(StateHandle {
+            past: state,
+            state_provider: Arc::new(Mutex::new(provider)),
+            state_provider_resource: resource.clone(),
+        }))
+    }
+
+    pub async fn resource_event(
+        &self,
+        resource_name: &String,
+        event: &str,
+        past_resource: Option<&ResourceState>,
+        current_resource: &ResourceState,
+    ) -> Result<()> {
+        // Patch does not have a prefixing operation, so we reconstruct the relevant part of the state file for this
+        let current_json = serde_json::to_value(current_resource)
+            .context("Failed to serialize current resource")?;
+        let current_json = serde_json::json!({
+            "resources": {
+                resource_name: current_json
+            }
+        });
+        let past_json = match past_resource {
+            None => serde_json::json!({"resources": { }}),
+            Some(past_resource) => {
+                let past_json = serde_json::to_value(past_resource)
+                    .context("Failed to serialize past resource")?;
+                serde_json::json!({
+                    "resources": {
+                        resource_name: past_json
+                    }
+                })
+            }
+        };
+
+        let patch = json_patch::diff(&past_json, &current_json);
+        let patch_value_list = patch
+            .iter()
+            .map(|patch_operation| {
+                let patch_operation = patch_operation.clone();
+                serde_json::to_value(patch_operation).context("Failed to serialize diff")
+            })
+            .collect::<Result<Vec<Value>>>()?;
+        self.state_provider
+            .lock()
+            .await
+            .state_event(v0::StateResourceEvent {
+                resource: self.state_provider_resource.clone(),
+                event: event.to_string(),
+                nixops_version: "0.1.0".to_string(),
+                patch: patch_value_list.clone(),
+            })
+            .await
+            .with_context(||
+                 format!("Failed to update state for resource {}. The following state update was lost: {}", resource_name, serde_json::to_string(&patch_value_list).unwrap())
+            )?;
+        Ok(())
+    }
+}
+impl std::fmt::Debug for StateHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "State {{ ... }}")
+    }
 }

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -89,7 +89,7 @@ runCommand
       [[ ! -e file.txt ]]
 
       grep -F 'oh no, this and that failed' err.log
-      grep -F 'Failed to create resource hello' err.log
+      grep -F 'Failed to create stateless resource hello' err.log
 
       touch $out
     )


### PR DESCRIPTION
# Stateful

This adds an optional `state` parameter to resources to make them _stateful_.
It creates a link from the stateful resources to a _state provider_ resource that records and replays the state for potentially multiple stateful resources.

# `local.memo` resource

This is a resource that is initialized with a declared value. After creation, its `value` attribute is _not_ update.
This could be used for providing the NixOS state version, or potentially other migration mechanisms.
Most of all, it was a simple resource that's easy to implement.

# Async, concurrency

A lot of the code is now async with `tokio` as runtime.
The `nixops apply` "scheduling" logic was rewritten to provide more flexibility and cyclic dependency reporting.

# TODO

- [ ] Documentation
- [ ] Tests of various kinds
- [ ] Cleanups (DRY, among other things)
- [ ] Allow certain inputs and outputs to be omitted from the state (e.g. local credentials)
- [ ] _Destroy_ operation
  - Named providers?
- [ ] _Read_ operation?

### Later?

- [ ] Save stateless resource info in state file too, optionally
- [ ] Default state resource
- [ ] Stateful `exec` resource, or is that just asking for trouble, enabling ad-hoc, second-class provider implementations?
- [ ] `local.timestamp` resource (like memo, but saves a timestamp)
- [ ] `local.random`/`local.uuid` resource (like `memo`, but saves some entropy)
- [ ] flag for `local.exec` that makes its output behave like `memo`

### Ideas

I'll write issues for these if I haven't already

- [ ] Nested deployments. These seem within reach thanks to the new `apply` architecture (`Bob`), but needs some work to support resource paths instead of just names everywhere.
- [ ] Concurrent realisation: when realising a provider or input that's been evaluated, spawn a separate task that does the realisation and replies to the request. This frees up the command reader loop to do more eval work

----------

<details><summary>Very first integrated user-created state file</summary>

```json
{
  "index": 0,
  "meta": {
    "time": "2025-04-15T11:48:06.434450914+00:00"
  },
  "patch": [
    {
      "op": "add",
      "path": "",
      "value": {
        "_type": "nixopsState",
        "deployments": {},
        "resources": {}
      }
    }
  ]
}
{
  "index": 0,
  "meta": {
    "time": "2025-04-18T14:40:48.756258645+00:00",
    "event": "create"
  },
  "patch": [
    {
      "op": "add",
      "path": "/resources/test3",
      "value": {
        "input_properties": {
          "initialize_with": {
            "hello": "world"
          }
        },
        "output_properties": {
          "value": {
            "hello": "world"
          }
        },
        "type": "memo"
      }
    }
  ]
}
{
  "index": 0,
  "meta": {
    "time": "2025-04-18T14:41:31.896024255+00:00",
    "event": "update"
  },
  "patch": []
}
{
  "index": 0,
  "meta": {
    "time": "2025-04-18T14:45:22.149685445+00:00",
    "event": "update"
  },
  "patch": [
    {
      "op": "replace",
      "path": "/resources/test3/input_properties/initialize_with/hello",
      "value": "World"
    }
  ]
}
```

</details>