### PR TITLE
specify deployment class in `deployment/base-modules.nix`

### DIFF
--- a/nix/deployment/base-modules.nix
+++ b/nix/deployment/base-modules.nix
@@ -1,4 +1,6 @@
 {
+  _class = "nixops4Deployment";
+
   imports = [
     ./resources.nix
     ./providers.nix


### PR DESCRIPTION
makes it match the class used in lib and tests