### PR TITLE
Component path shell completions + cleanups

### DIFF
--- a/bash-completion-wordbreaks.patch
+++ b/bash-completion-wordbreaks.patch
@@ -1,0 +1,36 @@
+Patch the clap_complete generated bash script to avoid splitting on ':'
+
+Bash's COMP_WORDBREAKS includes ':' by default, causing arguments like
+'github:foo/bar' to be split incorrectly during completion. This uses
+_get_comp_words_by_ref from bash-completion to preserve colons.
+
+TODO: Remove when clap_complete gains native support for this.
+--- completion.bash
++++ completion.bash
+@@ -1,16 +1,23 @@
+
+ _clap_complete_nixops4() {
+     local IFS=$'\013'
+-    local _CLAP_COMPLETE_INDEX=${COMP_CWORD}
+     local _CLAP_COMPLETE_COMP_TYPE=${COMP_TYPE}
+     if compopt +o nospace 2> /dev/null; then
+         local _CLAP_COMPLETE_SPACE=false
+     else
+         local _CLAP_COMPLETE_SPACE=true
+     fi
+-    local words=("${COMP_WORDS[@]}")
++    # Use _get_comp_words_by_ref to avoid COMP_WORDBREAKS splitting on ':'
++    local words cword
++    if type _get_comp_words_by_ref &>/dev/null; then
++        _get_comp_words_by_ref -n : words cword
++    else
++        words=("${COMP_WORDS[@]}")
++        cword=${COMP_CWORD}
++    fi
++    local _CLAP_COMPLETE_INDEX=${cword}
+     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+-        words[COMP_CWORD]="$2"
++        words[cword]="$2"
+     fi
+     COMPREPLY=( $( \
+         _CLAP_IFS="$IFS" \

--- a/package.nix
+++ b/package.nix
@@ -27,8 +27,9 @@ stdenv.mkDerivation {
       ;
 
     nixops4 generate-man > nixops4.1
-    nixops4 generate-completion --shell bash > completion.bash
-    nixops4 generate-completion --shell zsh > completion.zsh 
+
+    COMPLETE=bash nixops4 > completion.bash
+    COMPLETE=zsh nixops4 > completion.zsh
   '';
 
   installPhase = ''

--- a/package.nix
+++ b/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation {
     nixops4 generate-man > nixops4.1
 
     COMPLETE=bash nixops4 > completion.bash
+    patch -p0 < ${./bash-completion-wordbreaks.patch}
+
     COMPLETE=zsh nixops4 > completion.zsh
   '';
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -308,6 +308,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -700,6 +703,15 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/rust/nixops4/Cargo.toml
+++ b/rust/nixops4/Cargo.toml
@@ -18,7 +18,7 @@ nixops4-core = { path = "../nixops4-core" }
 nixops4-resource = { path = "../nixops4-resource" }
 nixops4-resource-runner = { path = "../nixops4-resource-runner" }
 clap = "4.5"
-clap_complete = "4.5"
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap-markdown = "0.1"

--- a/rust/nixops4/src/application.rs
+++ b/rust/nixops4/src/application.rs
@@ -1,0 +1,131 @@
+use crate::control::task_tracker::TaskTracker;
+use crate::eval_client::{self, EvalSender};
+use crate::interrupt::InterruptState;
+use crate::work::WorkContext;
+use crate::Options;
+use anyhow::{Context, Result};
+use nixops4_core::eval_api::{AssignRequest, EvalRequest, EvalResponse, FlakeRequest, RootRequest};
+use pubsub_rs::Pubsub;
+use std::future::Future;
+use std::process::exit;
+use std::sync::Arc;
+
+/// Create the single-threaded tokio runtime used by the CLI.
+///
+/// Panics if the runtime cannot be created.
+pub fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to initialize tokio runtime")
+}
+
+/// Handle a Result, printing the error and exiting with code 1 on failure.
+pub fn handle_result(r: Result<()>) {
+    match r {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("nixops4 error: {:?}", e);
+            exit(1);
+        }
+    }
+}
+
+/// Convert CLI options to eval client options.
+pub fn to_eval_options(options: &Options) -> eval_client::Options {
+    eval_client::Options {
+        verbose: options.verbose,
+        show_trace: options.show_trace,
+        flake_input_overrides: options
+            .override_input
+            .chunks(2)
+            .map(|pair| {
+                assert!(
+                    pair.len() == 2,
+                    "override_input must have an even number of elements (clap num_args = 2)"
+                );
+                (pair[0].to_string(), pair[1].to_string())
+            })
+            .collect(),
+    }
+}
+
+/// Run a command with evaluation context.
+///
+/// Sets up the evaluator subprocess, loads the flake and root, creates
+/// a `WorkContext` and `TaskTracker`, and spawns the response handler.
+/// After the provided function completes, cleans up resources.
+pub async fn with_eval<F, Fut, R>(
+    interrupt_state: &InterruptState,
+    options: &Options,
+    f: F,
+) -> Result<R>
+where
+    F: FnOnce(Arc<WorkContext>, TaskTracker<WorkContext>) -> Fut,
+    Fut: Future<Output = Result<R>>,
+{
+    let eval_options = to_eval_options(options);
+
+    EvalSender::with(&eval_options.clone(), |s, mut r| async move {
+        let flake_id = s.next_id();
+        let cwd = std::env::current_dir()
+            .context("getting current directory")?
+            .to_string_lossy()
+            .to_string();
+        s.send(&EvalRequest::LoadFlake(AssignRequest {
+            assign_to: flake_id,
+            payload: FlakeRequest {
+                abspath: cwd,
+                input_overrides: eval_options.flake_input_overrides.clone(),
+            },
+        }))
+        .await?;
+
+        let root_id = s.next_id();
+        s.send(&EvalRequest::LoadRoot(AssignRequest {
+            assign_to: root_id,
+            payload: RootRequest { flake: flake_id },
+        }))
+        .await?;
+
+        let work_context = WorkContext {
+            root_composite_id: root_id,
+            options: options.clone(),
+            interrupt_state: interrupt_state.clone(),
+            eval_sender: s.clone(),
+            state: Default::default(),
+            id_subscriptions: Pubsub::new(),
+        };
+
+        let id_subscriptions = work_context.id_subscriptions.clone();
+        let work_context = Arc::new(work_context);
+        let tasks = TaskTracker::new(work_context.clone());
+
+        let h: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async move {
+            while let Some(msg) = r.recv().await {
+                match &msg {
+                    EvalResponse::Error(id, _) => {
+                        id_subscriptions.publish(id.num(), msg).await;
+                    }
+                    EvalResponse::QueryResponse(id, _) => {
+                        id_subscriptions.publish(id.num(), msg).await;
+                    }
+                    EvalResponse::TracingEvent(_) => {
+                        // Already handled in an EvalSender::with thread
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        let result = f(work_context, tasks).await;
+
+        if result.is_ok() {
+            s.close().await;
+            h.await??;
+        }
+
+        result
+    })
+    .await
+}

--- a/rust/nixops4/src/application.rs
+++ b/rust/nixops4/src/application.rs
@@ -1,8 +1,8 @@
 use crate::control::task_tracker::TaskTracker;
 use crate::eval_client::{self, EvalSender};
 use crate::interrupt::InterruptState;
+use crate::options::Options;
 use crate::work::WorkContext;
-use crate::Options;
 use anyhow::{Context, Result};
 use nixops4_core::eval_api::{AssignRequest, EvalRequest, EvalResponse, FlakeRequest, RootRequest};
 use pubsub_rs::Pubsub;

--- a/rust/nixops4/src/application.rs
+++ b/rust/nixops4/src/application.rs
@@ -120,10 +120,8 @@ where
 
         let result = f(work_context, tasks).await;
 
-        if result.is_ok() {
-            s.close().await;
-            h.await??;
-        }
+        s.close().await;
+        h.await??;
 
         result
     })

--- a/rust/nixops4/src/application.rs
+++ b/rust/nixops4/src/application.rs
@@ -47,6 +47,7 @@ pub fn to_eval_options(options: &Options) -> eval_client::Options {
                 (pair[0].to_string(), pair[1].to_string())
             })
             .collect(),
+        force_quiet: false,
     }
 }
 

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -1,17 +1,11 @@
 use crate::{
-    control::task_tracker::TaskTracker,
-    eval_client::EvalSender,
+    application,
     interrupt::InterruptState,
-    to_eval_options,
-    work::{clone_anyhow_from_arc, resolve_composite_path, Goal, MutationCapability, WorkContext},
+    work::{clone_anyhow_from_arc, resolve_composite_path, Goal, MutationCapability},
     Options,
 };
-use anyhow::{bail, Context, Result};
-use nixops4_core::eval_api::{
-    AssignRequest, ComponentPath, EvalRequest, EvalResponse, FlakeRequest, RootRequest,
-};
-use pubsub_rs::Pubsub;
-use std::sync::Arc;
+use anyhow::{bail, Result};
+use nixops4_core::eval_api::ComponentPath;
 
 #[derive(clap::Parser, Debug)]
 pub(crate) struct Args {
@@ -54,116 +48,58 @@ pub(crate) async fn apply(
     };
     validate_no_overlapping_paths(&paths)?;
 
-    let eval_options = to_eval_options(options);
+    application::with_eval(interrupt_state, options, |work_context, tasks| async move {
+        // Spawn all path applications concurrently
+        let handles: Vec<_> = paths
+            .into_iter()
+            .map(|path| {
+                let tasks = tasks.clone();
+                tokio::spawn(async move {
+                    let target_id = resolve_composite_path(&tasks, path.clone()).await?;
 
-    EvalSender::with(&eval_options.clone(), |s, mut r| async move {
-        let flake_id = s.next_id();
-        let cwd = std::env::current_dir()
-            .context("getting current directory")?
-            .to_string_lossy()
-            .to_string();
-        s.send(&EvalRequest::LoadFlake(AssignRequest {
-            assign_to: flake_id,
-            payload: FlakeRequest {
-                abspath: cwd,
-                input_overrides: eval_options.flake_input_overrides.clone(),
-            },
-        }))
-        .await?;
-
-        let root_id = s.next_id();
-        s.send(&EvalRequest::LoadRoot(AssignRequest {
-            assign_to: root_id,
-            payload: RootRequest { flake: flake_id },
-        }))
-        .await?;
-
-        let work_context = WorkContext {
-            root_composite_id: root_id,
-            options: options.clone(),
-            interrupt_state: interrupt_state.clone(),
-            eval_sender: s.clone(),
-            state: Default::default(),
-            id_subscriptions: Pubsub::new(),
-        };
-
-        let id_subscriptions = work_context.id_subscriptions.clone();
-        let work_context = Arc::new(work_context);
-        let tasks = TaskTracker::new(work_context.clone());
-
-        let r = {
-            let h: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async move {
-                while let Some(msg) = r.recv().await {
-                    match &msg {
-                        EvalResponse::Error(id, _) => {
-                            id_subscriptions.publish(id.num(), msg).await;
-                        }
-                        EvalResponse::QueryResponse(id, _) => {
-                            id_subscriptions.publish(id.num(), msg).await;
-                        }
-                        EvalResponse::TracingEvent(_value) => {
-                            // Already handled in an EvalSender::with thread => ignore
-                        }
+                    // Apply with matching id/path
+                    match tasks
+                        .run(Goal::Apply(target_id, path, MutationCapability))
+                        .await
+                        .as_ref()
+                    {
+                        Ok(_) => Ok(()),
+                        Err(e) => Err(clone_anyhow_from_arc(e)),
                     }
-                }
-                Ok(())
-            });
-
-            // Spawn all path applications concurrently
-            let handles: Vec<_> = paths
-                .into_iter()
-                .map(|path| {
-                    let tasks = tasks.clone();
-                    tokio::spawn(async move {
-                        let target_id = resolve_composite_path(&tasks, path.clone()).await?;
-
-                        // Apply with matching id/path
-                        match tasks
-                            .run(Goal::Apply(target_id, path, MutationCapability))
-                            .await
-                            .as_ref()
-                        {
-                            Ok(_) => Ok(()),
-                            Err(e) => Err(clone_anyhow_from_arc(e)),
-                        }
-                    })
                 })
-                .collect();
+            })
+            .collect();
 
-            // Await all handles and collect errors
-            let mut errors = Vec::new();
-            for handle in handles {
-                match handle.await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => errors.push(e),
-                    Err(e) => errors.push(anyhow::anyhow!("Task panicked: {}", e)),
-                }
+        // Await all handles and collect errors
+        let mut errors = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => errors.push(e),
+                Err(e) => errors.push(anyhow::anyhow!("Task panicked: {}", e)),
             }
+        }
 
-            let result: Result<(), anyhow::Error> = if errors.is_empty() {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!(
-                    "{}",
-                    errors
-                        .iter()
-                        .map(|e| format!("{:#}", e))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                ))
-            };
-
-            // TODO: These cleanup operations should collect all errors and report them together
-            // instead of stopping at the first error, since we want all cleanup to complete
-
-            // Clean up state providers after apply completes - fatal error if this fails
-            work_context.clean_up_state_providers().await?;
-
-            s.close().await;
-            h.await??;
-            result
+        let result: Result<(), anyhow::Error> = if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "{}",
+                errors
+                    .iter()
+                    .map(|e| format!("{:#}", e))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ))
         };
-        r
+
+        // TODO: These cleanup operations should collect all errors and report them together
+        // instead of stopping at the first error, since we want all cleanup to complete
+
+        // Clean up state providers after apply completes - fatal error if this fails
+        work_context.clean_up_state_providers().await?;
+
+        result
     })
     .await
 }

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -48,7 +48,7 @@ pub(crate) async fn apply(
     };
     validate_no_overlapping_paths(&paths)?;
 
-    application::with_eval(interrupt_state, options, |work_context, tasks| async move {
+    application::with_eval(interrupt_state, options, |_work_ctx, tasks| async move {
         // Spawn all path applications concurrently
         let handles: Vec<_> = paths
             .into_iter()
@@ -92,12 +92,6 @@ pub(crate) async fn apply(
                     .join("\n")
             ))
         };
-
-        // TODO: These cleanup operations should collect all errors and report them together
-        // instead of stopping at the first error, since we want all cleanup to complete
-
-        // Clean up state providers after apply completes - fatal error if this fails
-        work_context.clean_up_state_providers().await?;
 
         result
     })

--- a/rust/nixops4/src/apply.rs
+++ b/rust/nixops4/src/apply.rs
@@ -1,16 +1,17 @@
 use crate::{
-    application,
+    application, complete,
     interrupt::InterruptState,
+    options::Options,
     work::{clone_anyhow_from_arc, resolve_composite_path, Goal, MutationCapability},
-    Options,
 };
 use anyhow::{bail, Result};
+use clap_complete::engine::ArgValueCompleter;
 use nixops4_core::eval_api::ComponentPath;
 
 #[derive(clap::Parser, Debug)]
 pub(crate) struct Args {
     /// Component paths to apply, including nested members and transitive dependencies (empty = entire root)
-    #[arg()]
+    #[arg(add = ArgValueCompleter::new(complete::component_path_completer_all))]
     paths: Vec<String>,
 }
 

--- a/rust/nixops4/src/complete.rs
+++ b/rust/nixops4/src/complete.rs
@@ -1,0 +1,185 @@
+//! Dynamic shell completion for component paths.
+
+use crate::application;
+use crate::work::{resolve_composite_path, Goal, Outcome};
+use clap_complete::engine::CompletionCandidate;
+use nixops4_core::eval_api::{ComponentHandle, ComponentPath};
+use std::ffi::OsStr;
+
+// Public functions
+// ----------------
+// `clap_complete` expects this function signature, so we have
+// to preapply our mode parameter. Consequently, `CompletionMode` is private.
+
+/// Completer for apply: both composites and resources are valid.
+pub fn component_path_completer_all(current: &OsStr) -> Vec<CompletionCandidate> {
+    component_path_completer_inner(current, CompletionMode::AllValid).unwrap_or_default()
+}
+
+/// Completer for destroy: only resources are valid targets.
+#[allow(dead_code)] // anticipated use in destroy command
+pub fn component_path_completer_resource(current: &OsStr) -> Vec<CompletionCandidate> {
+    component_path_completer_inner(current, CompletionMode::ResourceOnly).unwrap_or_default()
+}
+
+/// Completer for members list: only composites are valid targets.
+pub fn component_path_completer_composite(current: &OsStr) -> Vec<CompletionCandidate> {
+    component_path_completer_inner(current, CompletionMode::CompositeOnly).unwrap_or_default()
+}
+
+// Implementation
+// --------------
+
+/// Which component types are valid final targets.
+#[derive(Clone, Copy)]
+enum CompletionMode {
+    /// Both composites and resources are valid (e.g., apply).
+    AllValid,
+    /// Only resources are valid (e.g., destroy).
+    ResourceOnly,
+    /// Only composites are valid (e.g., members list).
+    CompositeOnly,
+}
+
+fn component_path_completer_inner(
+    current: &OsStr,
+    mode: CompletionMode,
+) -> anyhow::Result<Vec<CompletionCandidate>> {
+    let rt = application::try_runtime()?;
+    let current = current.to_string_lossy();
+
+    rt.block_on(async move {
+        application::with_eval_dead_quiet(|work_context, tasks| async move {
+            let root_id = work_context.root_composite_id;
+            complete_with_mode(&tasks, root_id, current.as_ref(), mode).await
+        })
+        .await
+    })
+}
+
+fn format_path(parent: Option<&str>, name: &str) -> String {
+    match parent {
+        Some(p) => format!("{}.{}", p, name),
+        None => name.to_string(),
+    }
+}
+
+/// Parse current input into parent path and prefix.
+fn parse_current(current: &str) -> (Option<&str>, &str) {
+    if let Some(dot_pos) = current.rfind('.') {
+        (Some(&current[..dot_pos]), &current[dot_pos + 1..])
+    } else {
+        (None, current)
+    }
+}
+
+/// List and filter member names at a path.
+///
+/// Crucially this must not determine component kind, so that it evaluates quickly.
+async fn list_filtered_members(
+    tasks: &crate::control::task_tracker::TaskTracker<crate::work::WorkContext>,
+    composite_id: nixops4_core::eval_api::Id<nixops4_core::eval_api::CompositeType>,
+    path: &nixops4_core::eval_api::ComponentPath,
+    prefix: &str,
+) -> anyhow::Result<Vec<String>> {
+    let result = tasks
+        .run(Goal::ListMembers(composite_id, path.clone(), None))
+        .await;
+
+    let names = match result.as_ref() {
+        Ok(Outcome::MembersListed(Ok(names))) => names.clone(),
+        _ => return Ok(vec![]),
+    };
+
+    Ok(names
+        .into_iter()
+        .filter(|n| n.starts_with(prefix))
+        .collect())
+}
+
+async fn complete_with_mode(
+    tasks: &crate::control::task_tracker::TaskTracker<crate::work::WorkContext>,
+    root_id: nixops4_core::eval_api::Id<nixops4_core::eval_api::CompositeType>,
+    current: &str,
+    mode: CompletionMode,
+) -> anyhow::Result<Vec<CompletionCandidate>> {
+    let (parent_path_str, prefix) = parse_current(current);
+    let parent_component_path: ComponentPath = parent_path_str.map_or(ComponentPath::root(), |s| {
+        s.parse().unwrap_or_else(|_| ComponentPath::root())
+    });
+    let composite_id = resolve_composite_path(tasks, parent_component_path.clone()).await?;
+
+    let parent_str = (!parent_component_path.is_root()).then(|| parent_component_path.to_string());
+    let parent_path = parent_str.as_deref();
+
+    let filtered =
+        list_filtered_members(tasks, composite_id, &parent_component_path, prefix).await?;
+
+    match filtered.len() {
+        0 => {
+            match mode {
+                CompletionMode::CompositeOnly => {
+                    // No members - suggest parent without dot (if current has parent)
+                    Ok(Vec::from_iter(
+                        parent_path.map(|p| CompletionCandidate::new(p.to_string())),
+                    ))
+                }
+                _ => Ok(vec![]),
+            }
+        }
+        1 => {
+            let name = &filtered[0];
+            let load_result = tasks
+                .run(Goal::LoadMember(composite_id, name.clone(), None))
+                .await;
+            let full_path = format_path(parent_path, name);
+
+            match load_result.as_ref() {
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Composite(_)))) => {
+                    match mode {
+                        CompletionMode::ResourceOnly => {
+                            // Need resource, so must drill down - do so immediately
+                            let child_current = format!("{}.", full_path);
+                            Box::pin(complete_with_mode(tasks, root_id, &child_current, mode)).await
+                        }
+                        CompletionMode::AllValid | CompletionMode::CompositeOnly => {
+                            // Offer as target and with dot to drill down
+                            Ok(vec![
+                                CompletionCandidate::new(full_path.clone()),
+                                CompletionCandidate::new(format!("{}.", full_path)),
+                            ])
+                        }
+                    }
+                }
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Resource(_)))) => {
+                    match mode {
+                        CompletionMode::AllValid | CompletionMode::ResourceOnly => {
+                            // Single resource - suggest as final completion
+                            Ok(vec![CompletionCandidate::new(full_path)])
+                        }
+                        CompletionMode::CompositeOnly => {
+                            // Not a valid target, fall back to parent
+                            if let Some(p) = parent_path {
+                                Ok(vec![CompletionCandidate::new(p.to_string())])
+                            } else {
+                                Ok(vec![])
+                            }
+                        }
+                    }
+                }
+                _ => Ok(vec![]),
+            }
+        }
+        _multiple => {
+            // No need to check kinds because user will tab again before these
+            // become final.
+            // Later, when the user narrows it down to a single candidate, we check
+            // the kind with just one LoadMember call. This results in the best
+            // performance.
+            Ok(filtered
+                .into_iter()
+                .map(|name| CompletionCandidate::new(format_path(parent_path, &name)))
+                .collect())
+        }
+    }
+}

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -4,6 +4,7 @@ mod control;
 mod eval_client;
 mod interrupt;
 mod logging;
+mod options;
 mod provider;
 mod state;
 mod work;
@@ -12,6 +13,7 @@ use anyhow::{bail, Result};
 use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
 use interrupt::{set_up_process_interrupt_handler, InterruptState};
 use nixops4_core::eval_api::ComponentPath;
+use options::Options;
 use work::{Goal, Outcome};
 
 fn main() {
@@ -154,34 +156,6 @@ struct Args {
 
     #[command(flatten)]
     options: Options,
-}
-
-#[derive(Parser, Debug, Clone)]
-struct Options {
-    #[arg(short, long, global = true, default_value = "false")]
-    verbose: bool,
-
-    #[arg(long, global = true, default_value_t = ColorChoice::Auto)]
-    color: ColorChoice,
-
-    #[arg(long, global = true, default_value_t = false)]
-    interactive: bool,
-
-    #[arg(
-        long,
-        global = true,
-        default_value_t = false,
-        conflicts_with = "interactive"
-    )]
-    no_interactive: bool,
-
-    #[arg(long, global = true, default_value_t = false)]
-    show_trace: bool,
-
-    /// Temporarily use a different flake input
-    // will be post-processed to pair them up
-    #[arg(long, num_args = 2, value_names = &["INPUT_ATTR_PATH", "FLAKE_REF"], global = true)]
-    override_input: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -115,7 +115,13 @@ fn to_eval_options(options: &Options) -> eval_client::Options {
         flake_input_overrides: options
             .override_input
             .chunks(2)
-            .map(|pair| (pair[0].to_string(), pair[1].to_string()))
+            .map(|pair| {
+                assert!(
+                    pair.len() == 2,
+                    "override_input must have an even number of elements (clap num_args = 2)"
+                );
+                (pair[0].to_string(), pair[1].to_string())
+            })
             .collect(),
     }
 }

--- a/rust/nixops4/src/options/lenient_parse.rs
+++ b/rust/nixops4/src/options/lenient_parse.rs
@@ -1,0 +1,501 @@
+//! Lenient command-line parsing for extracting options from partial input.
+//!
+//! During shell completion, we may have a partial command line. This module
+//! provides utilities to extract as many options as possible using binary
+//! search to find the longest parseable prefix.
+
+use clap::Parser;
+
+/// Parse the longest prefix of `args` that succeeds with the given parser.
+///
+/// Uses binary search with bounded linear probing. Assumes the parser has
+/// at most `MAX_GAP` consecutive invalid stopping points.
+///
+/// Returns `None` if even an empty argument list fails to parse.
+pub fn parse_longest_prefix<P: Parser>(args: &[String]) -> Option<P> {
+    heuristic_largest_valid(args.len(), |n| P::try_parse_from(&args[..n]).ok())
+}
+
+// Implementation
+// --------------
+// The purpose of the rest of this file is to create some sort of lenient
+// parsing. This is really a clap or *maybe* a clap_complete responsibility,
+// so this code is a *WORKAROUND*. Do not gold-plate it any further.
+//
+// roberth: I suspect clap is geared towards performance instead of elegance and
+//          flexibility. Not even Haskell's optparse-applicative gets this right,
+//          and I would argue it should be generalized to optparse-profunctor,
+//          allowing the context to be provided to completions. Possibly even a
+//          third type to generalize the return type for extra leniency.
+//          I wonder if those ideas could be implemented and ported to Rust.
+//          Or maybe I'm wrong about the clap design and the need for a "context"
+//          type parameter, and it's all over-engineered.
+//          I guess what I'm trying to say is: the below is kinda stupid, it
+//          kinda works, but don't improve it too much because it is very
+//          unprincipled, putting a ceiling on what it can ultimately do.
+
+/// Maximum number of consecutive invalid values between valid values.
+///
+/// The predicate must return `Some` for at least one value within every
+/// `MAX_GAP + 1` consecutive integers. This allows O(log n) binary search
+/// with O(CHUNK_SIZE) probing per iteration.
+const MAX_GAP: usize = 5;
+
+/// Chunk size for binary search. Must be > MAX_GAP to guarantee at least
+/// one valid value per chunk in the valid range.
+const CHUNK_SIZE: usize = MAX_GAP + 1;
+
+/// Find the largest `n` in `0..=max` where `predicate(n)` returns `Some`.
+///
+/// Uses binary search on chunks with linear probing within each chunk.
+/// Only guaranteed to find the largest valid value when there are at most
+/// `MAX_GAP` consecutive invalid values in the range `0..=max`.
+///
+/// Returns `None` if the predicate never returns `Some`.
+fn heuristic_largest_valid<R, F>(max: usize, predicate: F) -> Option<R>
+where
+    F: Fn(usize) -> Option<R>,
+{
+    // Fast path: if max is valid, return immediately
+    if let Some(result) = predicate(max) {
+        return Some(result);
+    }
+
+    let num_chunks = (max + CHUNK_SIZE) / CHUNK_SIZE;
+    let chunks: Vec<usize> = (0..num_chunks).collect();
+
+    let mut best_n: isize = -1;
+    let mut best: Option<R> = None;
+
+    let _ = chunks.partition_point(|&chunk_idx| {
+        let start = chunk_idx * CHUNK_SIZE;
+        let end = ((chunk_idx + 1) * CHUNK_SIZE).min(max + 1);
+
+        // Scan chunk from high to low to find highest valid in this chunk
+        for n in (start..end).rev() {
+            if let Some(result) = predicate(n) {
+                if (n as isize) > best_n {
+                    best_n = n as isize;
+                    best = Some(result);
+                }
+                return true; // chunk has valid value
+            }
+        }
+        false // no valid value in chunk
+    });
+
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test parser with a simple flag
+    #[derive(Parser, Debug, PartialEq)]
+    #[command(no_binary_name = true)]
+    struct SimpleFlags {
+        #[arg(short, long)]
+        verbose: bool,
+
+        #[arg(short, long)]
+        quiet: bool,
+    }
+
+    /// Test parser with multi-value argument
+    #[derive(Parser, Debug, PartialEq)]
+    #[command(no_binary_name = true)]
+    struct MultiValue {
+        #[arg(long, num_args = 2, action = clap::ArgAction::Append)]
+        pair: Vec<String>,
+    }
+
+    /// Test parser that accepts trailing arguments
+    #[derive(Parser, Debug, PartialEq)]
+    #[command(no_binary_name = true)]
+    struct WithTrailing {
+        #[arg(long)]
+        flag: bool,
+
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        rest: Vec<String>,
+    }
+
+    // Test parser that accepts three-item groups
+    #[derive(Parser, Debug, PartialEq)]
+    #[command(no_binary_name = true)]
+    struct KVArgs {
+        #[arg(long, num_args = 2, value_names = &["IDENT", "VALUE"])]
+        set_value: Vec<String>,
+    }
+
+    /// Test parser mimicking OptionsWrapper: global options + trailing for subcommand
+    #[derive(Parser, Debug, PartialEq)]
+    #[command(no_binary_name = true)]
+    struct OptionsLike {
+        #[arg(long, num_args = 2)]
+        override_input: Vec<String>,
+
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        rest: Vec<String>,
+    }
+
+    #[test]
+    fn test_override_input_before_subcommand() {
+        let args: Vec<String> = vec![
+            "--override-input",
+            "nixpkgs",
+            "NixOS/nixpkgs/nixos-unstable",
+            "apply",
+            "",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let result: Option<OptionsLike> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(OptionsLike {
+                override_input: vec![
+                    "nixpkgs".to_string(),
+                    "NixOS/nixpkgs/nixos-unstable".to_string()
+                ],
+                rest: vec!["apply".to_string(), "".to_string()]
+            })
+        );
+    }
+
+    #[test]
+    fn test_empty_args() {
+        let result: Option<SimpleFlags> = parse_longest_prefix(&[]);
+        assert_eq!(
+            result,
+            Some(SimpleFlags {
+                verbose: false,
+                quiet: false
+            })
+        );
+    }
+
+    #[test]
+    fn test_simple_flags() {
+        let args = vec!["--verbose".to_string()];
+        let result: Option<SimpleFlags> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(SimpleFlags {
+                verbose: true,
+                quiet: false
+            })
+        );
+    }
+
+    #[test]
+    fn test_multiple_flags() {
+        let args = vec!["--verbose".to_string(), "--quiet".to_string()];
+        let result: Option<SimpleFlags> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(SimpleFlags {
+                verbose: true,
+                quiet: true
+            })
+        );
+    }
+
+    #[test]
+    fn test_multi_value_complete() {
+        let args = vec![
+            "--pair".to_string(),
+            "key1".to_string(),
+            "value1".to_string(),
+        ];
+        let result: Option<MultiValue> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(MultiValue {
+                pair: vec!["key1".to_string(), "value1".to_string()]
+            })
+        );
+    }
+
+    #[test]
+    fn test_multi_value_multiple() {
+        let args = vec![
+            "--pair".to_string(),
+            "k1".to_string(),
+            "v1".to_string(),
+            "--pair".to_string(),
+            "k2".to_string(),
+            "v2".to_string(),
+        ];
+        let result: Option<MultiValue> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(MultiValue {
+                pair: vec![
+                    "k1".to_string(),
+                    "v1".to_string(),
+                    "k2".to_string(),
+                    "v2".to_string()
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_multi_value_incomplete() {
+        // Only one value provided instead of two
+        let args = vec!["--pair".to_string(), "key1".to_string()];
+        let result: Option<MultiValue> = parse_longest_prefix(&args);
+        // Should fall back to parsing empty prefix
+        assert_eq!(result, Some(MultiValue { pair: vec![] }));
+    }
+
+    #[test]
+    fn test_unknown_flag_stops_parsing() {
+        let args = vec![
+            "--verbose".to_string(),
+            "--unknown".to_string(),
+            "--quiet".to_string(),
+        ];
+        let result: Option<SimpleFlags> = parse_longest_prefix(&args);
+        // Should parse up to --verbose
+        assert_eq!(
+            result,
+            Some(SimpleFlags {
+                verbose: true,
+                quiet: false
+            })
+        );
+    }
+
+    #[test]
+    fn test_trailing_captures_rest() {
+        let args = vec!["--flag".to_string(), "pos1".to_string(), "pos2".to_string()];
+        let result: Option<WithTrailing> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(WithTrailing {
+                flag: true,
+                rest: vec!["pos1".to_string(), "pos2".to_string()]
+            })
+        );
+    }
+
+    #[test]
+    fn test_trailing_captures_rest_kv_arg() {
+        let args = vec![
+            "--set-value".to_string(),
+            "pos1".to_string(),
+            "pos2".to_string(),
+            "--set-value".to_string(),
+            "pos3".to_string(),
+            "pos4".to_string(),
+            "bad-1".to_string(),
+            "--set-value".to_string(), // doesn't matter
+            "bad-2".to_string(),
+            "bad-3".to_string(),
+            "bad-4".to_string(),
+            "bad-5".to_string(),
+            "bad-6".to_string(),
+            "bad-7".to_string(),
+            "bad-8".to_string(),
+            "bad-9".to_string(),
+            "bad-10".to_string(),
+        ];
+        let result: Option<KVArgs> = parse_longest_prefix(&args);
+        assert_eq!(
+            result,
+            Some(KVArgs {
+                set_value: vec![
+                    "pos1".to_string(),
+                    "pos2".to_string(),
+                    "pos3".to_string(),
+                    "pos4".to_string()
+                ]
+            })
+        );
+    }
+
+    // Tests for heuristic_largest_valid algorithm
+
+    #[test]
+    fn test_heuristic_none_valid() {
+        // No values are valid
+        let result: Option<usize> = heuristic_largest_valid(10, |_| None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_heuristic_max_zero_invalid() {
+        // Edge case: max = 0, but invalid
+        let result: Option<usize> = heuristic_largest_valid(0, |_| None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_heuristic_various_max_values() {
+        // Test with max invalid (valid only up to max-1) to exercise binary search
+        for max in 1..=50 {
+            let result = heuristic_largest_valid(max, |n| if n < max { Some(n) } else { None });
+            assert_eq!(result, Some(max - 1), "failed for max={}", max);
+        }
+    }
+
+    #[test]
+    fn test_heuristic_various_thresholds() {
+        // Test valid up to threshold (excluding threshold=max to exercise binary search)
+        for max in [100, 101, 102, 103, 104, 105] {
+            for threshold in 0..max {
+                let result =
+                    heuristic_largest_valid(max, |n| if n <= threshold { Some(n) } else { None });
+                assert_eq!(
+                    result,
+                    Some(threshold),
+                    "failed for max={}, threshold={}",
+                    max,
+                    threshold
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_heuristic_various_gap_sizes() {
+        // Test gaps from 1 to MAX_GAP with various max values around chunk boundaries.
+        // `gap` is the number of invalid values between consecutive valid values.
+        // With n % (gap + 1) == 0: valid at 0, gap+1, 2*(gap+1), ...
+        // e.g., gap=5 gives valid at 0, 6, 12, ... with 5 invalid values between each.
+        for gap in 1..=MAX_GAP {
+            for max in [50, 51, 52, 53, 54, 55] {
+                let spacing = gap + 1;
+                let result =
+                    heuristic_largest_valid(max, |n| if n % spacing == 0 { Some(n) } else { None });
+                let expected = (max / spacing) * spacing;
+                assert_eq!(
+                    result,
+                    Some(expected),
+                    "failed for gap={}, max={}",
+                    gap,
+                    max
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_heuristic_single_valid_at_each_position() {
+        // Test cutoff at each position (excluding cutoff=max to exercise binary search)
+        for max in [30, 31, 32, 33, 34, 35] {
+            for cutoff in 0..max {
+                let result =
+                    heuristic_largest_valid(max, |n| if n <= cutoff { Some(n) } else { None });
+                assert_eq!(
+                    result,
+                    Some(cutoff),
+                    "failed for max={}, cutoff={}",
+                    max,
+                    cutoff
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_heuristic_returns_correct_result_value() {
+        // Verify we return the result from the predicate (with max invalid)
+        for max in [5, 6, 7, 10, 11, 12, 20, 50, 51, 52] {
+            let result = heuristic_largest_valid(max, |n| if n < max { Some(n * 2) } else { None });
+            assert_eq!(result, Some((max - 1) * 2), "failed for max={}", max);
+        }
+    }
+
+    #[test]
+    fn test_heuristic_empty_suffix() {
+        // Valid from 0 to various cutoff points (excluding cutoff=max)
+        for max in [10, 11, 12, 25, 50, 51, 100, 101, 102] {
+            for cutoff in [0, 1, max / 4, max / 2, max - 1] {
+                let result =
+                    heuristic_largest_valid(max, |n| if n <= cutoff { Some(n) } else { None });
+                assert_eq!(
+                    result,
+                    Some(cutoff),
+                    "failed for max={}, cutoff={}",
+                    max,
+                    cutoff
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_heuristic_max_valid_single_call() {
+        use std::cell::Cell;
+
+        // Whenever max is valid, it should be found in exactly 1 predicate call
+        for max in [
+            0, 1, 5, 6, 7, 10, 11, 12, 13, 14, 15, 20, 50, 51, 100, 101, 102, 103, 104, 105, 200,
+            500, 1000,
+        ] {
+            let count = Cell::new(0usize);
+            let result = heuristic_largest_valid(max, |n| {
+                count.set(count.get() + 1);
+                Some(n)
+            });
+            assert_eq!(result, Some(max), "wrong result for max={}", max);
+            assert_eq!(
+                count.get(),
+                1,
+                "expected 1 call for max={}, got {}",
+                max,
+                count.get()
+            );
+        }
+    }
+
+    #[test]
+    fn test_heuristic_predicate_call_count() {
+        use std::cell::Cell;
+
+        // Count predicate calls with max invalid to exercise binary search
+        // Include values around chunk boundaries (CHUNK_SIZE = 6)
+        for max in [
+            10, 11, 12, 13, 14, 15, 20, 50, 100, 101, 102, 103, 104, 105, 200, 500, 1000,
+        ] {
+            let threshold = max / 2;
+            let count = Cell::new(0usize);
+            let result = heuristic_largest_valid(max, |n| {
+                count.set(count.get() + 1);
+                if n <= threshold {
+                    Some(n)
+                } else {
+                    None
+                }
+            });
+            assert_eq!(result, Some(threshold));
+
+            let num_chunks = (max + CHUNK_SIZE) / CHUNK_SIZE;
+            // Binary search visits O(log num_chunks) chunks
+            // Each chunk scans up to CHUNK_SIZE values
+            let expected_max_calls = ((num_chunks as f64).log2().ceil() as usize + 1) * CHUNK_SIZE;
+
+            println!(
+                "max={:4}, chunks={:3}, calls={:4}, expected_max={:4}",
+                max,
+                num_chunks,
+                count.get(),
+                expected_max_calls
+            );
+
+            assert!(
+                count.get() <= expected_max_calls,
+                "Too many calls for max={}: got {}, expected <= {}",
+                max,
+                count.get(),
+                expected_max_calls
+            );
+        }
+    }
+}

--- a/rust/nixops4/src/options/mod.rs
+++ b/rust/nixops4/src/options/mod.rs
@@ -1,3 +1,5 @@
+pub mod lenient_parse;
+
 use clap::{ColorChoice, Parser};
 
 #[derive(Parser, Debug, Clone)]

--- a/rust/nixops4/src/options/mod.rs
+++ b/rust/nixops4/src/options/mod.rs
@@ -1,6 +1,7 @@
 pub mod lenient_parse;
 
 use clap::{ColorChoice, Parser};
+use lenient_parse::parse_longest_prefix;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Options {
@@ -28,4 +29,39 @@ pub struct Options {
     // will be post-processed to pair them up
     #[arg(long, num_args = 2, value_names = &["INPUT_ATTR_PATH", "FLAKE_REF"], global = true)]
     pub override_input: Vec<String>,
+}
+
+/// Wrapper to parse global Options from a partial command line.
+///
+/// Used by lenient parsing during shell completion.
+#[derive(Parser, Debug)]
+#[command(no_binary_name = true)]
+struct OptionsWrapper {
+    #[command(flatten)]
+    options: Options,
+
+    // Catch subcommands and their args without failing
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+    _rest: Vec<String>,
+}
+
+/// Parse global options from the current environment's command line.
+///
+/// For use during shell completion, where we have a partial command line
+/// but want to extract options like `--override-input` that the user has
+/// already specified.
+///
+/// Returns the successfully parsed options, or clap's default options if parsing fails.
+pub fn parse_options_for_completion() -> Options {
+    // Get the raw args, skipping everything before "--" which is clap_complete's
+    // convention for separating completer args from the actual command line
+    let args: Vec<String> = std::env::args()
+        .skip_while(|a| a != "--")
+        .skip(1) // skip the "--" itself
+        .skip(1) // skip the command name (e.g., "nixops4")
+        .collect();
+
+    parse_longest_prefix::<OptionsWrapper>(&args)
+        .expect("OptionsWrapper parses empty args with default values")
+        .options
 }

--- a/rust/nixops4/src/options/mod.rs
+++ b/rust/nixops4/src/options/mod.rs
@@ -1,0 +1,29 @@
+use clap::{ColorChoice, Parser};
+
+#[derive(Parser, Debug, Clone)]
+pub struct Options {
+    #[arg(short, long, global = true, default_value = "false")]
+    pub verbose: bool,
+
+    #[arg(long, global = true, default_value_t = ColorChoice::Auto)]
+    pub color: ColorChoice,
+
+    #[arg(long, global = true, default_value_t = false)]
+    pub interactive: bool,
+
+    #[arg(
+        long,
+        global = true,
+        default_value_t = false,
+        conflicts_with = "interactive"
+    )]
+    pub no_interactive: bool,
+
+    #[arg(long, global = true, default_value_t = false)]
+    pub show_trace: bool,
+
+    /// Temporarily use a different flake input
+    // will be post-processed to pair them up
+    #[arg(long, num_args = 2, value_names = &["INPUT_ATTR_PATH", "FLAKE_REF"], global = true)]
+    pub override_input: Vec<String>,
+}

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -208,7 +208,7 @@ pub enum Outcome {
 }
 
 pub struct WorkContext {
-    pub options: crate::Options,
+    pub options: crate::options::Options,
     pub eval_sender: eval_client::EvalSender,
     pub root_composite_id: Id<CompositeType>,
     pub interrupt_state: InterruptState,

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -1414,6 +1414,18 @@ pub(crate) fn clone_anyhow_from_arc(e: &Arc<anyhow::Error>) -> anyhow::Error {
     err
 }
 
+/// Resolve a component path to a composite ID.
+pub(crate) async fn resolve_composite_path(
+    tasks: &crate::control::task_tracker::TaskTracker<WorkContext>,
+    path: ComponentPath,
+) -> Result<Id<CompositeType>> {
+    match tasks.run(Goal::ResolveCompositePath(path)).await.as_ref() {
+        Ok(Outcome::CompositeResolved(id)) => Ok(*id),
+        Ok(other) => bail!("Unexpected outcome from ResolveCompositePath: {:?}", other),
+        Err(e) => Err(clone_anyhow_from_arc(e)),
+    }
+}
+
 fn indented_json(v: &Value) -> String {
     let s = serde_json::to_string_pretty(v).unwrap();
     s.replace("\n", "\n            ")


### PR DESCRIPTION
A cleaned up history pulled from #150 and some local WIP.
This performs preparations for both
- completions #146
- avoiding duplication in #150

and then thoroughly solves completions, working around significant clap problems.

Admittedly tests are lacking for completions (esp integration), but that might just be the right tradeoff for now.