### PR TITLE
dev/flake-module: remove gdb for darwin for now

### DIFF
--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -90,9 +90,11 @@
             pkgs.rustfmt
             pkgs.pkg-config
             pkgs.clang-tools # clangd
-            pkgs.gdb
             pkgs.hci
             inputs'.nix-unit.packages.nix-unit
+          ]
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            pkgs.gdb # Currently broken on darwin see https://github.com/NixOS/nixpkgs/issues/483562 for more info
           ]
           ++ config.packages.manual.externalBuildTools;
           shellHook = ''


### PR DESCRIPTION
There are major issues with building gdb on darwin, for now we should disable this so you can actually get into the dev environment working

Ref: https://github.com/NixOS/nixpkgs/issues/483562