### PR TITLE
Diagnostic commands and `exec` <- `once`

### DIFF
--- a/doc/manual/src/concept/resource.md
+++ b/doc/manual/src/concept/resource.md
@@ -26,6 +26,19 @@ When a resource type has `requireState = false`:
 - The resource does not need a state handler
 - The resource is stateless and can be idempotently recreated from its inputs
 
+### Skipping Unchanged Resources
+
+When NixOps applies a stateful resource whose inputs haven't changed since the last apply, it considers the resource up to date and does not perform the update operation.
+This keeps deployments fast by only invoking providers when inputs actually change.
+
+This relies on two assumptions:
+
+1. **No out-of-band changes**: the resource has not been modified outside of NixOps.
+   Drift detection and reconciliation [will be](https://github.com/nixops4/nixops4/issues/161) NixOps responsibilities, but they are not part of the normal `apply` flow, because that would unnecessarily slow down deployments.
+   If your deployment needs drift detection, it should run continuously rather than on update, so that problems are detected promptly.
+2. **No significant side effects**: the update operation does not perform essential work beyond bringing the resource to its desired state.
+   Concerns such as lease renewal are outside the scope of resource providers and should be handled by services or scheduled tasks instead.
+
 ## Resource Dependencies
 
 Resources can depend on each other in two different ways:

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -83,6 +83,15 @@ in
               Optional input to provide on stdin.
             '';
           };
+          once = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              When true, the command executes only on create; updates preserve the original output.
+              This is similar to the [`memo`](memo.md) resource type.
+              Requires the [`state`](../../modules/index.md#opt-state) to be set.
+            '';
+          };
         };
       };
       outputs = {

--- a/nix/providers/local.nix
+++ b/nix/providers/local.nix
@@ -83,6 +83,15 @@ in
               Optional input to provide on stdin.
             '';
           };
+          once = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              When true, the command executes only on create; updates preserve the original output.
+              This is similar to the [`memo`](memo.md) resource type.
+              Requires the resource to be stateful (isStateful).
+            '';
+          };
         };
       };
       outputs = {

--- a/rust/nixops4-resources-local/src/main.rs
+++ b/rust/nixops4-resources-local/src/main.rs
@@ -27,10 +27,12 @@ struct ExecInProperties {
     executable: String,
     args: Vec<String>,
     stdin: Option<String>,
+    #[serde(default)]
+    once: bool,
     // TODO parseJSON: bool  (for convenience and presentation purposes)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct ExecOutProperties {
     stdout: String,
 }
@@ -63,48 +65,15 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
                 std::fs::write(&p.name, &p.contents)?;
                 Ok(FileOutProperties {})
             }),
-            "exec" => do_create(request, |p: ExecInProperties| {
-                let mut command = std::process::Command::new(&p.executable);
-                command.args(&p.args);
-
-                let in_stdio = if p.stdin.is_some() {
-                    std::process::Stdio::piped()
-                } else {
-                    std::process::Stdio::null()
-                };
-
-                let mut child = command
-                    .stdin(in_stdio)
-                    .stdout(std::process::Stdio::piped())
-                    .spawn()
-                    .with_context(|| {
-                        format!(
-                            "Could not spawn resource provider process: {}",
-                            p.executable
-                        )
-                    })?;
-
-                if let Some(stdinstr) = p.stdin {
-                    child
-                        .stdin
-                        .as_mut()
-                        .unwrap()
-                        .write_all(stdinstr.as_bytes())?;
-                }
-
-                // Read stdout
-                let output = child.wait_with_output()?;
-                let stdout = String::from_utf8(output.stdout)?;
-
-                if output.status.success() {
-                    Ok(ExecOutProperties { stdout })
-                } else {
-                    bail!(
-                        "Local resource process failed with exit code: {}",
-                        output.status
-                    )
-                }
-            }),
+            "exec" => {
+                let is_stateful = request.is_stateful;
+                do_create(request, |p: ExecInProperties| {
+                    if p.once && !is_stateful {
+                        bail!("exec resource with once=true requires state (use isStateful)");
+                    }
+                    run_exec(p)
+                })
+            }
             "memo" => {
                 if !request.is_stateful {
                     bail!("memo resources require state (isStateful must be true)");
@@ -157,9 +126,21 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
             "file" => {
                 bail!("Internal error: update called on stateless file resource");
             }
-            "exec" => {
-                bail!("Internal error: update called on stateless exec resource");
-            }
+            "exec" => do_update(&request, |p: ExecInProperties| {
+                if p.once {
+                    let previous_output_properties = request.resource.output_properties.as_ref().ok_or_else(|| {
+                        anyhow::anyhow!("The update operation on an exec resource with once=true requires previous output properties (received None)")
+                    })?;
+                    let previous: ExecOutProperties =
+                        serde_json::from_value(Value::Object(previous_output_properties.0.clone()))
+                            .with_context(|| {
+                                "Could not deserialize output properties for exec resource"
+                            })?;
+                    Ok(previous)
+                } else {
+                    run_exec(p)
+                }
+            }),
             "state_file" => {
                 bail!("Internal error: update called on stateless state_file resource");
             }
@@ -255,6 +236,49 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
                 t
             ),
         }
+    }
+}
+
+fn run_exec(p: ExecInProperties) -> Result<ExecOutProperties> {
+    let mut command = std::process::Command::new(&p.executable);
+    command.args(&p.args);
+
+    let in_stdio = if p.stdin.is_some() {
+        std::process::Stdio::piped()
+    } else {
+        std::process::Stdio::null()
+    };
+
+    let mut child = command
+        .stdin(in_stdio)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "Could not spawn resource provider process: {}",
+                p.executable
+            )
+        })?;
+
+    if let Some(stdinstr) = p.stdin {
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(stdinstr.as_bytes())?;
+    }
+
+    // Read stdout
+    let output = child.wait_with_output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    if output.status.success() {
+        Ok(ExecOutProperties { stdout })
+    } else {
+        bail!(
+            "Local resource process failed with exit code: {}",
+            output.status
+        )
     }
 }
 

--- a/rust/nixops4-resources-local/src/main.rs
+++ b/rust/nixops4-resources-local/src/main.rs
@@ -27,10 +27,12 @@ struct ExecInProperties {
     executable: String,
     args: Vec<String>,
     stdin: Option<String>,
+    #[serde(default)]
+    once: bool,
     // TODO parseJSON: bool  (for convenience and presentation purposes)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct ExecOutProperties {
     stdout: String,
 }
@@ -63,48 +65,24 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
                 std::fs::write(&p.name, &p.contents)?;
                 Ok(FileOutProperties {})
             }),
-            "exec" => do_create(request, |p: ExecInProperties| {
-                let mut command = std::process::Command::new(&p.executable);
-                command.args(&p.args);
-
-                let in_stdio = if p.stdin.is_some() {
-                    std::process::Stdio::piped()
-                } else {
-                    std::process::Stdio::null()
+            "exec" => {
+                let props: ExecInProperties = serde_json::from_value(Value::Object(
+                    request.input_properties.0.into_iter().collect(),
+                ))
+                .with_context(|| "Could not deserialize input properties for exec resource")?;
+                if props.once && !request.is_stateful {
+                    bail!("exec resource with once=true requires state (use isStateful)");
+                }
+                let out = run_exec(props)?;
+                let out_value = serde_json::to_value(out)?;
+                let out_object = match out_value {
+                    Value::Object(o) => o,
+                    _ => bail!("Expected object as output"),
                 };
-
-                let mut child = command
-                    .stdin(in_stdio)
-                    .stdout(std::process::Stdio::piped())
-                    .spawn()
-                    .with_context(|| {
-                        format!(
-                            "Could not spawn resource provider process: {}",
-                            p.executable
-                        )
-                    })?;
-
-                if let Some(stdinstr) = p.stdin {
-                    child
-                        .stdin
-                        .as_mut()
-                        .unwrap()
-                        .write_all(stdinstr.as_bytes())?;
-                }
-
-                // Read stdout
-                let output = child.wait_with_output()?;
-                let stdout = String::from_utf8(output.stdout)?;
-
-                if output.status.success() {
-                    Ok(ExecOutProperties { stdout })
-                } else {
-                    bail!(
-                        "Local resource process failed with exit code: {}",
-                        output.status
-                    )
-                }
-            }),
+                Ok(v0::CreateResourceResponse {
+                    output_properties: v0::OutputProperties(out_object.into_iter().collect()),
+                })
+            }
             "memo" => {
                 if !request.is_stateful {
                     bail!("memo resources require state (isStateful must be true)");
@@ -157,9 +135,24 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
             "file" => {
                 bail!("Internal error: update called on stateless file resource");
             }
-            "exec" => {
-                bail!("Internal error: update called on stateless exec resource");
-            }
+            "exec" => do_update(&request, |p: ExecInProperties| {
+                if p.once {
+                    let previous_output_properties = request.resource.output_properties.as_ref().ok_or_else(|| {
+                        anyhow::anyhow!("The update operation on an exec resource with once=true requires previous output properties (received None)")
+                    })?;
+                    let previous: ExecOutProperties = serde_json::from_value(Value::Object(
+                        previous_output_properties
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                    ))
+                    // Cannot fail: output was serialized by us on create
+                    .with_context(|| "Could not deserialize output properties for exec resource")?;
+                    Ok(previous)
+                } else {
+                    run_exec(p)
+                }
+            }),
             "state_file" => {
                 bail!("Internal error: update called on stateless state_file resource");
             }
@@ -248,6 +241,49 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
                 t
             ),
         }
+    }
+}
+
+fn run_exec(p: ExecInProperties) -> Result<ExecOutProperties> {
+    let mut command = std::process::Command::new(&p.executable);
+    command.args(&p.args);
+
+    let in_stdio = if p.stdin.is_some() {
+        std::process::Stdio::piped()
+    } else {
+        std::process::Stdio::null()
+    };
+
+    let mut child = command
+        .stdin(in_stdio)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "Could not spawn resource provider process: {}",
+                p.executable
+            )
+        })?;
+
+    if let Some(stdinstr) = p.stdin {
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(stdinstr.as_bytes())?;
+    }
+
+    // Read stdout
+    let output = child.wait_with_output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    if output.status.success() {
+        Ok(ExecOutProperties { stdout })
+    } else {
+        bail!(
+            "Local resource process failed with exit code: {}",
+            output.status
+        )
     }
 }
 

--- a/rust/nixops4-resources-local/src/main.rs
+++ b/rust/nixops4-resources-local/src/main.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 mod state;
-use state::{StateEvent, StateEventMeta, StateEventStream, StateHandle};
+use state::{StateEvent, StateEventMeta, StateEventStream, StateHandle, WaitMonitor};
 
 struct LocalResourceProvider {}
 
@@ -202,12 +202,19 @@ impl nixops4_resource::framework::ResourceProvider for LocalResourceProvider {
                     &request.resource.type_,
                 )?;
 
-                let file_contents = std::fs::read_to_string(inputs.name.as_str())?;
-                let stream = StateEventStream::open_from_reader(io::BufReader::new(
-                    file_contents.as_bytes(),
-                ))?;
+                let file = OpenOptions::new().read(true).open(inputs.name.as_str())?;
+                let locking = fd_lock::RwLock::new(file);
+                let read_guard = {
+                    let mon = WaitMonitor::new("Waiting for state file read lock".to_owned());
+                    let g = locking.read()?;
+                    mon.done();
+                    g
+                };
+
+                let stream = StateEventStream::open_from_reader(io::BufReader::new(&*read_guard))?;
                 let mut state = serde_json::json!({});
                 state::apply_state_events(&mut state, stream)?;
+                drop(read_guard);
                 Ok(v0::StateResourceReadResponse {
                     state: serde_json::from_value(state)?,
                 })

--- a/rust/nixops4/src/logging/headless.rs
+++ b/rust/nixops4/src/logging/headless.rs
@@ -10,7 +10,17 @@ use tracing_subscriber::{
 
 pub(crate) struct HeadlessLogger {}
 
-pub(crate) type Logger = Layered<LevelFilter2<FmtLayer<Registry>>, Registry>;
+pub(crate) type Logger = Layered<
+    LevelFilter2<
+        FmtLayer<
+            Registry,
+            tracing_subscriber::fmt::format::DefaultFields,
+            tracing_subscriber::fmt::format::Format,
+            fn() -> std::io::Stderr,
+        >,
+    >,
+    Registry,
+>;
 
 impl HeadlessLogger {
     pub(crate) fn make_subscriber(&mut self, options: &super::Options) -> Result<Logger> {
@@ -30,6 +40,7 @@ impl HeadlessLogger {
         };
 
         let fmt_layer = FmtLayer::new()
+            .with_writer(std::io::stderr as fn() -> std::io::Stderr)
             .with_span_events(span_events)
             .with_ansi(options.color);
         let filter_layer = LevelFilter2::new(filter.into(), fmt_layer);

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -10,7 +10,7 @@ mod provider;
 mod state;
 mod work;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
@@ -116,37 +116,39 @@ async fn members_list(
 ) -> Result<Vec<String>> {
     let target_path: ComponentPath = path.map_or(ComponentPath::root(), |s| s.parse().unwrap());
 
-    // TODO: Support nested paths by traversing to the composite
-    if !target_path.is_root() {
-        bail!(
-            "Listing members at nested paths is not yet implemented. Use root path (no argument)."
-        );
-    }
+    application::with_eval(
+        interrupt_state,
+        options,
+        |_work_context, tasks| async move {
+            let composite_id = work::resolve_composite_path(&tasks, target_path.clone())
+                .await
+                .context(format!(
+                    "Failed to resolve path '{}' for members list",
+                    target_path
+                ))?;
 
-    application::with_eval(interrupt_state, options, |work_context, tasks| async move {
-        let root_id = work_context.root_composite_id;
+            // Use ListMembers goal without mutation capability (preview mode)
+            let result = tasks
+                .run(Goal::ListMembers(composite_id, target_path.clone(), None))
+                .await;
 
-        // Use ListMembers goal without mutation capability (preview mode)
-        let result = tasks
-            .run(Goal::ListMembers(root_id, target_path.clone(), None))
-            .await;
-
-        // Extract member names from the result
-        match result.as_ref() {
-            Ok(Outcome::MembersListed(Ok(names))) => Ok(names.clone()),
-            Ok(Outcome::MembersListed(Err(preview_item))) => {
-                bail!(
-                    "Cannot list members at '{}': blocked by structural dependency: {}",
-                    target_path,
-                    preview_item
-                )
+            // Extract member names from the result
+            match result.as_ref() {
+                Ok(Outcome::MembersListed(Ok(names))) => Ok(names.clone()),
+                Ok(Outcome::MembersListed(Err(preview_item))) => {
+                    bail!(
+                        "Cannot list members at '{}': blocked by structural dependency: {}",
+                        target_path,
+                        preview_item
+                    )
+                }
+                Ok(other) => {
+                    bail!("Unexpected outcome from ListMembers: {:?}", other)
+                }
+                Err(e) => bail!("Failed to list members at '{}': {}", target_path, e),
             }
-            Ok(other) => {
-                bail!("Unexpected outcome from ListMembers: {:?}", other)
-            }
-            Err(e) => bail!("Failed to list members at '{}': {}", target_path, e),
-        }
-    })
+        },
+    )
     .await
 }
 
@@ -163,9 +165,14 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Members {
-    /// List members at a component path (default: root)
+    /// List members at a component path (default: root).
+    ///
+    /// This is a read-only command that does not create or modify resources.
+    /// If the member set depends on a resource output (a structural dependency),
+    /// the command fails instead of showing incomplete results.
     List {
-        /// Component path (dot-separated, e.g., "production.database")
+        /// Component path (dot-separated, e.g., "production.database").
+        /// Must resolve to a composite (deployment), not a resource.
         #[arg(add = ArgValueCompleter::new(complete::component_path_completer_composite))]
         path: Option<String>,
     },

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -15,9 +15,9 @@ use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
 use interrupt::{set_up_process_interrupt_handler, InterruptState};
-use nixops4_core::eval_api::ComponentPath;
+use nixops4_core::eval_api::{ComponentHandle, ComponentPath};
 use options::Options;
-use work::{Goal, Outcome};
+use work::{clone_anyhow_from_arc, Goal, Outcome};
 
 fn main() {
     // Handle shell completion if requested via environment.
@@ -54,6 +54,17 @@ async fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
                     for m in members {
                         println!("{}", m);
                     }
+                }
+            };
+            Ok(())
+        }
+        Commands::State(sub) => {
+            match sub {
+                State::Dump { path } => {
+                    let mut logging = set_up_logging(interrupt_state, &args)?;
+                    let json = dump_state(interrupt_state, &args.options, path).await?;
+                    logging.tear_down()?;
+                    println!("{}", json);
                 }
             };
             Ok(())
@@ -152,6 +163,87 @@ async fn members_list(
     .await
 }
 
+/// Dump the state of a state-providing resource as JSON.
+///
+/// Reads the state without applying any resources. Data may be stale.
+async fn dump_state(
+    interrupt_state: &InterruptState,
+    options: &Options,
+    path: &str,
+) -> Result<String> {
+    let resource_path: ComponentPath = path.parse().unwrap();
+
+    application::with_eval(
+        interrupt_state,
+        options,
+        |_work_context, tasks| async move {
+            // Split path into parent composite + resource name
+            let (parent_path, name) = resource_path
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("Cannot dump state for root path"))?;
+
+            // Resolve parent composite
+            let parent_id = work::resolve_composite_path(&tasks, parent_path)
+                .await
+                .context(format!("Failed to dump state stored in {}", resource_path))?;
+
+            // Load the member and verify it's a resource
+            let load_result = tasks
+                .run(Goal::LoadMember(parent_id, name.to_string(), None))
+                .await;
+            let resource_id = match load_result.as_ref() {
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Resource(id)))) => *id,
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Composite(_)))) => {
+                    bail!(
+                        "'{}' is a composite (deployment), not an individual resource. \
+                         Specify a state-providing resource, e.g., '{}.state'.",
+                        resource_path,
+                        resource_path
+                    )
+                }
+                Ok(Outcome::MemberLoaded(Err(dep))) => {
+                    // TODO: resolve by reading the depended-on resource's outputs from its state-providing resource, which works when that's a different state-providing resource
+                    bail!(
+                        "Cannot load '{}': blocked by structural dependency: {}",
+                        resource_path,
+                        dep
+                    )
+                }
+                Ok(other) => bail!("Unexpected outcome from LoadMember: {:?}", other),
+                Err(e) => {
+                    return Err(clone_anyhow_from_arc(e))
+                        .context(format!("Failed to dump state stored in {}", resource_path))
+                }
+            };
+
+            let run_result = tasks
+                .run(Goal::RunState(
+                    resource_id,
+                    resource_path.clone(),
+                    None, /* read-only: resolves inputs without applying */
+                ))
+                .await;
+            let state_handle = match run_result.as_ref() {
+                Ok(Outcome::RunState(handle)) => handle.clone(),
+                Ok(other) => bail!("Unexpected outcome from RunState: {:?}", other),
+                Err(e) => {
+                    return Err(clone_anyhow_from_arc(e)).context(format!(
+                        "'{}' could not be read as a state provider",
+                        resource_path
+                    ))
+                }
+            };
+
+            // Read current state and serialize to JSON
+            let state = state_handle.current.lock().await;
+            let json = serde_json::to_string_pretty(&*state)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize state: {}", e))?;
+            Ok(json)
+        },
+    )
+    .await
+}
+
 /// NixOps: manage resources declaratively
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -179,6 +271,19 @@ enum Members {
 }
 
 #[derive(Subcommand, Debug)]
+enum State {
+    /// Dump the current state of a state-providing resource as JSON.
+    ///
+    /// This is a read-only command that does not create or modify resources.
+    /// If the resource path cannot be resolved without applying other resources
+    /// (e.g., it depends on another resource's output), the command fails.
+    Dump {
+        /// Path to a state-providing resource (dot-separated, e.g., "myDeployment.state")
+        path: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum Commands {
     /// Apply changes so that the resources are in the desired state.
     ///
@@ -190,6 +295,10 @@ enum Commands {
     /// Commands that operate on component members
     #[command(subcommand)]
     Members(Members),
+
+    /// Commands that operate on deployment state
+    #[command(subcommand)]
+    State(State),
 
     /// Generate markdown documentation for nixops4-resource-runner
     #[command(hide = true)]

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -15,9 +15,9 @@ use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
 use interrupt::{set_up_process_interrupt_handler, InterruptState};
-use nixops4_core::eval_api::ComponentPath;
+use nixops4_core::eval_api::{ComponentHandle, ComponentPath};
 use options::Options;
-use work::{Goal, Outcome};
+use work::{clone_anyhow_from_arc, Goal, Outcome};
 
 fn main() {
     // Handle shell completion if requested via environment.
@@ -54,6 +54,17 @@ async fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
                     for m in members {
                         println!("{}", m);
                     }
+                }
+            };
+            Ok(())
+        }
+        Commands::State(sub) => {
+            match sub {
+                State::Dump { path } => {
+                    let mut logging = set_up_logging(interrupt_state, &args)?;
+                    let json = dump_state(interrupt_state, &args.options, path.clone()).await?;
+                    logging.tear_down()?;
+                    println!("{}", json);
                 }
             };
             Ok(())
@@ -151,6 +162,90 @@ async fn members_list(
     .await
 }
 
+/// Dump the state stored in a state-providing resource as JSON.
+///
+/// Reads the state without applying any resources. Data may be stale.
+async fn dump_state(
+    interrupt_state: &InterruptState,
+    options: &Options,
+    resource_path: ComponentPath,
+) -> Result<String> {
+    application::with_eval(
+        interrupt_state,
+        options,
+        |_work_context, tasks| async move {
+            // Split path into parent composite + resource name
+            let (parent_path, name) = resource_path.parent().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "empty path refers to the root deployment, not a resource; \
+                     specify a state-providing resource, e.g. 'myDeployment.state'"
+                )
+            })?;
+
+            // Resolve parent composite
+            let parent_id = work::resolve_composite_path(&tasks, parent_path)
+                .await
+                .context(format!("Failed to dump state stored in {}", resource_path))?;
+
+            // Load the member and verify it's a resource
+            let load_result = tasks
+                .run(Goal::LoadMember(parent_id, name.to_string(), None))
+                .await;
+            let resource_id = match load_result.as_ref() {
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Resource(id)))) => *id,
+                Ok(Outcome::MemberLoaded(Ok(ComponentHandle::Composite(_)))) => {
+                    bail!(
+                        "'{}' is a composite (deployment), not an individual resource. \
+                         Specify a state-providing resource, e.g., '{}.state'.",
+                        resource_path,
+                        resource_path
+                    )
+                }
+                Ok(Outcome::MemberLoaded(Err(dep))) => {
+                    // TODO: resolve dependencies in read-only mode via state
+                    //       (https://github.com/nixops4/nixops4/issues/164)
+                    bail!(
+                        "Cannot load '{}': blocked by structural dependency (depends on {}.{})",
+                        resource_path,
+                        dep.depends_on.resource,
+                        dep.depends_on.name,
+                    )
+                }
+                Ok(other) => bail!("Unexpected outcome from LoadMember: {:?}", other),
+                Err(e) => {
+                    return Err(clone_anyhow_from_arc(e))
+                        .context(format!("Failed to dump state stored in {}", resource_path))
+                }
+            };
+
+            let run_result = tasks
+                .run(Goal::RunState(
+                    resource_id,
+                    resource_path.clone(),
+                    None, /* read-only: resolves inputs without applying */
+                ))
+                .await;
+            let state_handle = match run_result.as_ref() {
+                Ok(Outcome::RunState(handle)) => handle.clone(),
+                Ok(other) => bail!("Unexpected outcome from RunState: {:?}", other),
+                Err(e) => {
+                    return Err(clone_anyhow_from_arc(e)).context(format!(
+                        "'{}' could not be read as a state provider",
+                        resource_path
+                    ))
+                }
+            };
+
+            // Read current state and serialize to JSON
+            let state = state_handle.current.lock().await;
+            let json = serde_json::to_string_pretty(&*state)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize state: {}", e))?;
+            Ok(json)
+        },
+    )
+    .await
+}
+
 /// NixOps: manage resources declaratively
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -189,6 +284,24 @@ enum Members {
 }
 
 #[derive(Subcommand, Debug)]
+enum State {
+    /// Dump the current state stored in a state-providing resource as JSON.
+    ///
+    /// This is a read-only command that does not create or modify resources.
+    /// If the resource path cannot be resolved without applying other resources
+    /// (e.g., it depends on another resource's output), the command fails.
+    ///
+    /// Plumbing: the output is the raw state contents, which may contain
+    /// unencrypted secrets. Do not paste it into bug reports or send it over
+    /// untrusted channels without redacting first.
+    Dump {
+        /// Path to a state-providing resource (dot-separated, e.g., "myDeployment.state")
+        #[arg(add = ArgValueCompleter::new(complete::component_path_completer_resource))]
+        path: ComponentPath,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum Commands {
     /// Apply changes so that the resources are in the desired state.
     ///
@@ -200,6 +313,10 @@ enum Commands {
     /// Commands that operate on component members
     #[command(subcommand)]
     Members(Members),
+
+    /// Commands that operate on deployment state
+    #[command(subcommand)]
+    State(State),
 
     /// Generate markdown documentation for nixops4-resource-runner
     #[command(hide = true)]

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -134,11 +134,12 @@ async fn members_list(
         // Extract member names from the result
         match result.as_ref() {
             Ok(Outcome::MembersListed(Ok(names))) => Ok(names.clone()),
-            Ok(Outcome::MembersListed(Err(preview_item))) => {
+            Ok(Outcome::MembersListed(Err(dep))) => {
                 bail!(
-                    "Cannot list members at '{}': blocked by structural dependency: {}",
+                    "Cannot list members at '{}': blocked by structural dependency (depends on {}.{})",
                     target_path,
-                    preview_item
+                    dep.depends_on.resource,
+                    dep.depends_on.name,
                 )
             }
             Ok(other) => {

--- a/rust/nixops4/src/main.rs
+++ b/rust/nixops4/src/main.rs
@@ -10,7 +10,7 @@ mod provider;
 mod state;
 mod work;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use clap::{ColorChoice, CommandFactory as _, Parser, Subcommand};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
@@ -49,7 +49,7 @@ async fn run_args(interrupt_state: &InterruptState, args: Args) -> Result<()> {
                 Members::List { path } => {
                     let mut logging = set_up_logging(interrupt_state, &args)?;
                     let members =
-                        members_list(interrupt_state, &args.options, path.as_deref()).await?;
+                        members_list(interrupt_state, &args.options, path.clone()).await?;
                     logging.tear_down()?;
                     for m in members {
                         println!("{}", m);
@@ -112,42 +112,42 @@ fn set_up_logging(
 async fn members_list(
     interrupt_state: &InterruptState,
     options: &Options,
-    path: Option<&str>,
+    target_path: ComponentPath,
 ) -> Result<Vec<String>> {
-    let target_path: ComponentPath = path.map_or(ComponentPath::root(), |s| s.parse().unwrap());
+    application::with_eval(
+        interrupt_state,
+        options,
+        |_work_context, tasks| async move {
+            let composite_id = work::resolve_composite_path(&tasks, target_path.clone())
+                .await
+                .context(format!(
+                    "Failed to resolve path '{}' for members list",
+                    target_path
+                ))?;
 
-    // TODO: Support nested paths by traversing to the composite
-    if !target_path.is_root() {
-        bail!(
-            "Listing members at nested paths is not yet implemented. Use root path (no argument)."
-        );
-    }
+            // Use ListMembers goal without mutation capability (preview mode)
+            let result = tasks
+                .run(Goal::ListMembers(composite_id, target_path.clone(), None))
+                .await;
 
-    application::with_eval(interrupt_state, options, |work_context, tasks| async move {
-        let root_id = work_context.root_composite_id;
-
-        // Use ListMembers goal without mutation capability (preview mode)
-        let result = tasks
-            .run(Goal::ListMembers(root_id, target_path.clone(), None))
-            .await;
-
-        // Extract member names from the result
-        match result.as_ref() {
-            Ok(Outcome::MembersListed(Ok(names))) => Ok(names.clone()),
-            Ok(Outcome::MembersListed(Err(dep))) => {
-                bail!(
-                    "Cannot list members at '{}': blocked by structural dependency (depends on {}.{})",
-                    target_path,
-                    dep.depends_on.resource,
-                    dep.depends_on.name,
-                )
+            // Extract member names from the result
+            match result.as_ref() {
+                Ok(Outcome::MembersListed(Ok(names))) => Ok(names.clone()),
+                Ok(Outcome::MembersListed(Err(dep))) => {
+                    bail!(
+                        "Cannot list members at '{}': blocked by structural dependency (depends on {}.{})",
+                        target_path,
+                        dep.depends_on.resource,
+                        dep.depends_on.name,
+                    )
+                }
+                Ok(other) => {
+                    bail!("Unexpected outcome from ListMembers: {:?}", other)
+                }
+                Err(e) => bail!("Failed to list members at '{}': {}", target_path, e),
             }
-            Ok(other) => {
-                bail!("Unexpected outcome from ListMembers: {:?}", other)
-            }
-            Err(e) => bail!("Failed to list members at '{}': {}", target_path, e),
-        }
-    })
+        },
+    )
     .await
 }
 
@@ -164,11 +164,27 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Members {
-    /// List members at a component path (default: root)
+    /// List members at a component path (default: root).
+    ///
+    /// This is a read-only command that does not create or modify resources.
+    /// If the member set depends on a resource output (a structural dependency),
+    /// the command fails instead of showing incomplete results.
     List {
-        /// Component path (dot-separated, e.g., "production.database")
-        #[arg(add = ArgValueCompleter::new(complete::component_path_completer_composite))]
-        path: Option<String>,
+        /// Component path (dot-separated, e.g., "production.database").
+        /// Must resolve to a composite (deployment), not a resource.
+        // `default_value = ""` because `default_value_t = ComponentPath::root()`
+        // round-trips through Display+FromStr, and `Display` of root is `(root)`,
+        // which then parses back to a single-segment path `["(root)"]`. Empty
+        // string is the right on-the-wire form and FromStr("") returns root.
+        // `hide_default_value = true` because rendering the empty default as
+        // `[default: ]` in --help reads oddly; the enum docstring already says
+        // "(default: root)".
+        #[arg(
+            default_value = "",
+            hide_default_value = true,
+            add = ArgValueCompleter::new(complete::component_path_completer_composite),
+        )]
+        path: ComponentPath,
     },
 }
 

--- a/rust/nixops4/src/state.rs
+++ b/rust/nixops4/src/state.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 use crate::provider;
 
 /// The root of a state file.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct State {
     #[serde(flatten)]
     pub deployment: DeploymentState,

--- a/rust/nixops4/src/state.rs
+++ b/rust/nixops4/src/state.rs
@@ -13,13 +13,13 @@ use tokio::sync::Mutex;
 use crate::provider;
 
 /// The root of a state file.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct State {
     #[serde(flatten)]
     pub deployment: DeploymentState,
 
     #[serde(deserialize_with = "type_is_nixops_state")]
-    _type: String,
+    pub _type: String,
 }
 
 fn type_is_nixops_state<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -1176,6 +1176,45 @@ impl WorkContext {
 
         let inputs = clone_result(inputs_thunk.force().await)?;
 
+        // Read past resource once and cache it for both the skip check and the
+        // later create-vs-update decision, avoiding a second state lock.
+        //
+        // Skip optimization: see "Skipping Unchanged Resources" in
+        // doc/manual/src/concept/resource.md for the assumptions.
+        let mut saved_past_resource: Option<crate::state::ResourceState> = None;
+        if let Some(ref state_handle) = state {
+            saved_past_resource = state_handle
+                .current
+                .lock()
+                .await
+                .deployment
+                .get_resource(&resource_path)
+                .cloned();
+            if let Some(ref past_resource) = saved_past_resource {
+                if past_resource.type_ != provider_info.resource_type {
+                    bail!(
+                        "Resource type change is not supported: {} != {}",
+                        past_resource.type_,
+                        provider_info.resource_type
+                    );
+                }
+                if inputs == past_resource.input_properties {
+                    tracing::info!(
+                        "Skipping update for resource {}: inputs unchanged",
+                        resource_path
+                    );
+                    return self
+                        .publish_resource_outputs(
+                            &resource_path,
+                            inputs,
+                            past_resource.output_properties.clone(),
+                            provider_info.resource_type,
+                        )
+                        .await;
+                }
+            }
+        }
+
         let span = info_span!(
             "creating resource",
             name = resource_path.to_string().as_str()
@@ -1205,22 +1244,10 @@ impl WorkContext {
                     format!("Failed to create stateless resource {}", resource_path)
                 })?,
             Some(ref state_handle) => {
-                let past_resource_opt = state_handle
-                    .current
-                    .lock()
-                    .await
-                    .deployment
-                    .get_resource(&resource_path)
-                    .cloned();
-                match past_resource_opt {
+                match saved_past_resource.take() {
                     Some(past_resource) => {
-                        if past_resource.type_ != provider_info.resource_type {
-                            bail!(
-                                "Resource type change is not supported: {} != {}",
-                                past_resource.type_,
-                                provider_info.resource_type
-                            );
-                        }
+                        // Type check already done above; inputs differ if we reach here
+                        tracing::debug!("Updating resource {}: inputs changed", resource_path);
                         let outputs = provider
                             .update(
                                 provider_info.resource_type.as_str(),

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -1089,6 +1089,42 @@ impl WorkContext {
         Ok((provider_info, inputs_thunk))
     }
 
+    /// Send resource outputs to the evaluator and return the final `ExtantResource`.
+    async fn publish_resource_outputs(
+        &self,
+        resource_path: &ComponentPath,
+        inputs: serde_json::Map<String, serde_json::Value>,
+        outputs: serde_json::Map<String, serde_json::Value>,
+        resource_type: String,
+    ) -> Result<Outcome> {
+        if self.options.verbose {
+            eprintln!("Resource outputs: {:?}", outputs);
+        }
+
+        // Send the outputs eagerly, to avoid roundtrips and costly
+        // re-evaluation when some output is "missing" but not really
+        for (output_name, output_value) in outputs.iter() {
+            let output_prop = NamedProperty {
+                resource: resource_path.clone(),
+                name: output_name.clone(),
+            };
+            self.eval_sender
+                .send(&EvalRequest::PutResourceOutput(
+                    output_prop,
+                    output_value.clone(),
+                ))
+                .await?;
+        }
+
+        let resource = nixops4_resource::schema::v0::ExtantResource {
+            input_properties: nixops4_resource::schema::v0::InputProperties(inputs),
+            output_properties: Some(nixops4_resource::schema::v0::OutputProperties(outputs)),
+            type_: nixops4_resource::schema::v0::ResourceType(resource_type),
+        };
+
+        Ok(Outcome::ResourceOutputs(resource))
+    }
+
     async fn perform_apply_resource(
         &self,
         context: TaskContext<Self>,
@@ -1240,37 +1276,13 @@ impl WorkContext {
 
         drop(span);
 
-        if self.options.verbose {
-            eprintln!("Resource outputs: {:?}", outputs);
-        }
-
-        // Send the outputs eagerly, to avoid roundtrips and costly
-        // re-evaluation when some output is "missing" but not really
-        for (output_name, output_value) in outputs.iter() {
-            let output_prop = NamedProperty {
-                resource: resource_path.clone(),
-                name: output_name.clone(),
-            };
-            self.eval_sender
-                .send(&EvalRequest::PutResourceOutput(
-                    output_prop,
-                    output_value.clone(),
-                ))
-                .await?;
-        }
-
         // Close the provider properly
         // We might want to reuse them in the future, but for now we launch one
         // per resource, except when it's a state provider (elsewhere).
         provider.close_wait().await?;
 
-        let resource = nixops4_resource::schema::v0::ExtantResource {
-            input_properties: nixops4_resource::schema::v0::InputProperties(inputs),
-            output_properties: Some(nixops4_resource::schema::v0::OutputProperties(outputs)),
-            type_: nixops4_resource::schema::v0::ResourceType(provider_info.resource_type),
-        };
-
-        Ok(Outcome::ResourceOutputs(resource))
+        self.publish_resource_outputs(&resource_path, inputs, outputs, provider_info.resource_type)
+            .await
     }
 }
 

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -1085,6 +1085,42 @@ impl WorkContext {
         Ok((provider_info, inputs_thunk))
     }
 
+    /// Send resource outputs to the evaluator and return the final `ExtantResource`.
+    async fn publish_resource_outputs(
+        &self,
+        resource_path: &ComponentPath,
+        inputs: serde_json::Map<String, serde_json::Value>,
+        outputs: serde_json::Map<String, serde_json::Value>,
+        resource_type: String,
+    ) -> Result<Outcome> {
+        if self.options.verbose {
+            eprintln!("Resource outputs: {:?}", outputs);
+        }
+
+        // Send the outputs eagerly, to avoid roundtrips and costly
+        // re-evaluation when some output is "missing" but not really
+        for (output_name, output_value) in outputs.iter() {
+            let output_prop = NamedProperty {
+                resource: resource_path.clone(),
+                name: output_name.clone(),
+            };
+            self.eval_sender
+                .send(&EvalRequest::PutResourceOutput(
+                    output_prop,
+                    output_value.clone(),
+                ))
+                .await?;
+        }
+
+        let resource = nixops4_resource::schema::v0::ExtantResource {
+            input_properties: nixops4_resource::schema::v0::InputProperties(inputs),
+            output_properties: Some(nixops4_resource::schema::v0::OutputProperties(outputs)),
+            type_: nixops4_resource::schema::v0::ResourceType(resource_type),
+        };
+
+        Ok(Outcome::ResourceOutputs(resource))
+    }
+
     async fn perform_apply_resource(
         &self,
         context: TaskContext<Self>,
@@ -1236,37 +1272,13 @@ impl WorkContext {
 
         drop(span);
 
-        if self.options.verbose {
-            eprintln!("Resource outputs: {:?}", outputs);
-        }
-
-        // Send the outputs eagerly, to avoid roundtrips and costly
-        // re-evaluation when some output is "missing" but not really
-        for (output_name, output_value) in outputs.iter() {
-            let output_prop = NamedProperty {
-                resource: resource_path.clone(),
-                name: output_name.clone(),
-            };
-            self.eval_sender
-                .send(&EvalRequest::PutResourceOutput(
-                    output_prop,
-                    output_value.clone(),
-                ))
-                .await?;
-        }
-
         // Close the provider properly
         // We might want to reuse them in the future, but for now we launch one
         // per resource, except when it's a state provider (elsewhere).
         provider.close_wait().await?;
 
-        let resource = nixops4_resource::schema::v0::ExtantResource {
-            input_properties: nixops4_resource::schema::v0::InputProperties(inputs),
-            output_properties: Some(nixops4_resource::schema::v0::OutputProperties(outputs)),
-            type_: nixops4_resource::schema::v0::ResourceType(provider_info.resource_type),
-        };
-
-        Ok(Outcome::ResourceOutputs(resource))
+        self.publish_resource_outputs(&resource_path, inputs, outputs, provider_info.resource_type)
+            .await
     }
 }
 

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -16,11 +16,7 @@ use nixops4_core::eval_api::{
 use nixops4_resource_runner::{ResourceProviderClient, ResourceProviderConfig};
 use pubsub_rs::Pubsub;
 use serde_json::Value;
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::Display,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, fmt::Display, sync::Arc};
 use std::{future::Future, pin::Pin};
 use tokio::sync::Mutex;
 use tracing::{info_span, Instrument as _};
@@ -989,13 +985,19 @@ impl WorkContext {
         }
     }
 
-    async fn perform_apply_resource(
+    /// Spawn tasks to resolve provider info and input values for a resource.
+    /// Returns provider info (forced) and a thunk for the input map (not yet
+    /// forced), so callers can spawn further work before forcing the inputs.
+    async fn resolve_resource_inputs(
         &self,
-        context: TaskContext<Self>,
+        context: &TaskContext<Self>,
         id: Id<ResourceType>,
-        resource_path: ComponentPath,
+        resource_path: &ComponentPath,
         mutation_cap: MutationCapability,
-    ) -> Result<Outcome> {
+    ) -> Result<(
+        ResourceProviderInfo,
+        Thunk<std::result::Result<serde_json::Map<String, serde_json::Value>, Arc<anyhow::Error>>>,
+    )> {
         let provider_info_thunk = context
             .spawn(Goal::GetResourceProviderInfo(
                 id,
@@ -1022,7 +1024,7 @@ impl WorkContext {
             }
         };
 
-        let mut inputs_thunks = HashMap::new();
+        let mut inputs_thunks = BTreeMap::new();
         for input_name in inputs_list {
             let input_id = context
                 .spawn(Goal::GetResourceInputValue(
@@ -1045,6 +1047,37 @@ impl WorkContext {
                 ),
             }
         };
+
+        let inputs_thunk = Thunk::new(async move {
+            let mut inputs = serde_json::Map::new();
+            for (input_name, thunk) in inputs_thunks {
+                match clone_result(thunk.force().await.as_ref()) {
+                    Ok(Outcome::ResourceInputValue(v)) => {
+                        inputs.insert(input_name, v);
+                    }
+                    Ok(outcome) => panic!(
+                        "Unexpected outcome from GetResourceInputValue: {:?}",
+                        outcome
+                    ),
+                    Err(e) => return Err(Arc::new(e)),
+                }
+            }
+            Ok(inputs)
+        });
+
+        Ok((provider_info, inputs_thunk))
+    }
+
+    async fn perform_apply_resource(
+        &self,
+        context: TaskContext<Self>,
+        id: Id<ResourceType>,
+        resource_path: ComponentPath,
+        mutation_cap: MutationCapability,
+    ) -> Result<Outcome> {
+        let (provider_info, inputs_thunk) = self
+            .resolve_resource_inputs(&context, id, &resource_path, mutation_cap)
+            .await?;
 
         let state_provider = match &provider_info.state {
             Some(state_resource_path) => {
@@ -1088,22 +1121,7 @@ impl WorkContext {
             None => None,
         };
 
-        let inputs = {
-            let mut inputs = serde_json::Map::new();
-            for (input_name, input_thunk) in inputs_thunks {
-                let outcome = clone_result(input_thunk.force().await.as_ref())?;
-                match outcome {
-                    Outcome::ResourceInputValue(i) => {
-                        inputs.insert(input_name, i);
-                    }
-                    _ => panic!(
-                        "Unexpected outcome from GetResourceInputValue: {:?}",
-                        outcome
-                    ),
-                }
-            }
-            inputs
-        };
+        let inputs = clone_result(inputs_thunk.force().await)?;
 
         let span = info_span!(
             "creating resource",

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -100,13 +100,18 @@ pub enum Goal {
     LoadMember(Id<CompositeType>, String, Option<MutationCapability>),
     /// Get resource provider info for a loaded resource.
     /// Note: path is only used for logging; id is the source of truth.
-    GetResourceProviderInfo(Id<ResourceType>, ComponentPath, MutationCapability),
+    GetResourceProviderInfo(Id<ResourceType>, ComponentPath, Option<MutationCapability>),
     /// List resource inputs.
     /// Note: path is only used for logging; id is the source of truth.
-    ListResourceInputs(Id<ResourceType>, ComponentPath, MutationCapability),
+    ListResourceInputs(Id<ResourceType>, ComponentPath, Option<MutationCapability>),
     /// Get a specific resource input value.
     /// Note: path is only used for logging; id is the source of truth.
-    GetResourceInputValue(Id<ResourceType>, ComponentPath, String, MutationCapability),
+    GetResourceInputValue(
+        Id<ResourceType>,
+        ComponentPath,
+        String,
+        Option<MutationCapability>,
+    ),
     /// Get a resource output value (goes to ApplyResource).
     /// Note: path is only used for logging; id is the source of truth.
     GetResourceOutputValue(Id<ResourceType>, ComponentPath, String, MutationCapability),
@@ -115,7 +120,7 @@ pub enum Goal {
     ApplyResource(Id<ResourceType>, ComponentPath, MutationCapability),
     /// Run a state provider resource.
     /// Note: path is only used for logging; id is the source of truth.
-    RunState(Id<ResourceType>, ComponentPath, MutationCapability),
+    RunState(Id<ResourceType>, ComponentPath, Option<MutationCapability>),
 }
 impl Display for Goal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -442,15 +447,25 @@ impl WorkContext {
         &self,
         context: &TaskContext<Self>,
         dep: &NamedProperty,
-        mutation_cap: MutationCapability,
+        mutation_cap: Option<MutationCapability>,
     ) -> Result<()> {
+        // TODO: pass the command name (e.g. "state dump") into the error
+        // so users know which invocation triggered read-only mode.
+        let cap = mutation_cap.with_context(|| {
+            format!(
+                "the current command uses the deployment in read-only mode, \
+                 but this depends on output {}.{}, which requires applying \
+                 that resource first",
+                dep.resource, dep.name
+            )
+        })?;
         let dep_id = self.get_resource_id(context, &dep.resource).await?;
         let r = context
             .require(Goal::GetResourceOutputValue(
                 dep_id,
                 dep.resource.clone(),
                 dep.name.clone(),
-                mutation_cap,
+                cap,
             ))
             .await
             .with_context(|| format!("resolving dependency {}.{}", dep.resource, dep.name))?;
@@ -674,7 +689,7 @@ impl WorkContext {
                     return Ok(Outcome::MembersListed(Ok(names)));
                 }
                 StepResult::Needs(dep) => match mutation_cap {
-                    Some(cap) => self.resolve_dependency(&context, &dep, cap).await?,
+                    Some(cap) => self.resolve_dependency(&context, &dep, Some(cap)).await?,
                     None => {
                         return Ok(Outcome::MembersListed(Err(
                             PreviewItem::StructuralDependency {
@@ -778,7 +793,7 @@ impl WorkContext {
                     return Ok(Outcome::MemberLoaded(Ok(handle)));
                 }
                 StepResult::Needs(dep) => match mutation_cap {
-                    Some(cap) => self.resolve_dependency(&context, &dep, cap).await?,
+                    Some(cap) => self.resolve_dependency(&context, &dep, Some(cap)).await?,
                     None => {
                         return Ok(Outcome::MemberLoaded(Err(
                             PreviewItem::StructuralDependency {
@@ -828,19 +843,20 @@ impl WorkContext {
 
     /// Get resource provider info, retrying on dependency.
     /// See [`StepResult::Needs`] for caching/retry semantics.
+    /// With mutation_cap None: errors on unresolved dependency instead of resolving it.
     async fn perform_get_resource_provider_info(
         &self,
         context: TaskContext<Self>,
         id: Id<ResourceType>,
         _resource_path: ComponentPath,
-        mutation_cap: MutationCapability,
+        mutation_cap: Option<MutationCapability>,
     ) -> Result<Outcome> {
         loop {
             match self.eval_get_resource_provider_info(id).await? {
                 StepResult::Done(info) => return Ok(Outcome::ResourceProviderInfo(info)),
                 StepResult::Needs(dep) => {
                     self.resolve_dependency(&context, &dep, mutation_cap)
-                        .await?
+                        .await?;
                 }
             }
         }
@@ -882,12 +898,13 @@ impl WorkContext {
 
     /// List resource inputs, retrying on dependency.
     /// See [`StepResult::Needs`] for caching/retry semantics.
+    /// With mutation_cap None: errors on unresolved dependency instead of resolving it.
     async fn perform_list_resource_inputs(
         &self,
         context: TaskContext<Self>,
         id: Id<ResourceType>,
         _resource_path: ComponentPath,
-        mutation_cap: MutationCapability,
+        mutation_cap: Option<MutationCapability>,
     ) -> Result<Outcome> {
         loop {
             match self.eval_list_resource_inputs(id).await? {
@@ -896,7 +913,7 @@ impl WorkContext {
                 }
                 StepResult::Needs(dep) => {
                     self.resolve_dependency(&context, &dep, mutation_cap)
-                        .await?
+                        .await?;
                 }
             }
         }
@@ -908,7 +925,7 @@ impl WorkContext {
         id: Id<ResourceType>,
         _resource_path: ComponentPath,
         input_name: String,
-        mutation_cap: MutationCapability,
+        mutation_cap: Option<MutationCapability>,
     ) -> Result<Outcome> {
         let msg_id = self.eval_sender.next_id();
         let rx = self.id_subscriptions.subscribe(vec![msg_id.num()]).await;
@@ -938,7 +955,7 @@ impl WorkContext {
                             }
                             StepResult::Needs(dep) => {
                                 self.resolve_dependency(&context, &dep, mutation_cap)
-                                    .await?
+                                    .await?;
                             }
                         },
                         _ => bail!(
@@ -993,7 +1010,7 @@ impl WorkContext {
         context: &TaskContext<Self>,
         id: Id<ResourceType>,
         resource_path: &ComponentPath,
-        mutation_cap: MutationCapability,
+        mutation_cap: Option<MutationCapability>,
     ) -> Result<(
         ResourceProviderInfo,
         Thunk<std::result::Result<serde_json::Map<String, serde_json::Value>, Arc<anyhow::Error>>>,
@@ -1076,7 +1093,7 @@ impl WorkContext {
         mutation_cap: MutationCapability,
     ) -> Result<Outcome> {
         let (provider_info, inputs_thunk) = self
-            .resolve_resource_inputs(&context, id, &resource_path, mutation_cap)
+            .resolve_resource_inputs(&context, id, &resource_path, Some(mutation_cap))
             .await?;
 
         let state_provider = match &provider_info.state {
@@ -1096,7 +1113,7 @@ impl WorkContext {
                     .spawn(Goal::RunState(
                         state_resource_id,
                         state_resource_path.clone(),
-                        mutation_cap,
+                        Some(mutation_cap),
                     ))
                     .await
                     .with_context(|| {
@@ -1354,34 +1371,63 @@ impl TaskWork for WorkContext {
 
             Goal::RunState(id, path, cap) => {
                 (async {
-                    // Apply the resource
-                    let r = context
-                        .require(Goal::ApplyResource(id, path.clone(), cap))
-                        .await
-                        .with_context(|| format!("Failed to apply resource {}", path))?;
-                    let resource = {
-                        let outcome = clone_result(r.as_ref())?;
-                        match outcome {
-                            Outcome::ResourceOutputs(i) => i,
-                            _ => panic!("Unexpected outcome from ApplyResource: {:?}", outcome),
-                        }
-                    };
+                    let (resource, provider_info) = match cap {
+                        Some(cap) => {
+                            // Mutating path: apply the resource first
+                            let r = context
+                                .require(Goal::ApplyResource(id, path.clone(), cap))
+                                .await
+                                .with_context(|| format!("Failed to apply resource {}", path))?;
+                            let resource = {
+                                let outcome = clone_result(r.as_ref())?;
+                                match outcome {
+                                    Outcome::ResourceOutputs(i) => i,
+                                    _ => panic!(
+                                        "Unexpected outcome from ApplyResource: {:?}",
+                                        outcome
+                                    ),
+                                }
+                            };
 
-                    // Get the provider info
-                    let provider_info_thunk = context
-                        .spawn(Goal::GetResourceProviderInfo(id, path.clone(), cap))
-                        .await
-                        .with_context(|| {
-                            format!("Failed to get provider info for resource {}", path)
-                        })?;
-                    let provider_info = {
-                        let outcome = clone_result(provider_info_thunk.force().await.as_ref())?;
-                        match outcome {
-                            Outcome::ResourceProviderInfo(i) => i,
-                            _ => panic!(
-                                "Unexpected outcome from GetResourceProviderInfo: {:?}",
-                                outcome
-                            ),
+                            // Get the provider info
+                            let provider_info_thunk = context
+                                .spawn(Goal::GetResourceProviderInfo(id, path.clone(), Some(cap)))
+                                .await
+                                .with_context(|| {
+                                    format!("Failed to get provider info for resource {}", path)
+                                })?;
+                            let provider_info = {
+                                let outcome =
+                                    clone_result(provider_info_thunk.force().await.as_ref())?;
+                                match outcome {
+                                    Outcome::ResourceProviderInfo(i) => i,
+                                    _ => panic!(
+                                        "Unexpected outcome from GetResourceProviderInfo: {:?}",
+                                        outcome
+                                    ),
+                                }
+                            };
+
+                            (resource, provider_info)
+                        }
+                        None => {
+                            // Read-only path: resolve inputs without applying
+                            let (provider_info, inputs_thunk) = self
+                                .resolve_resource_inputs(&context, id, &path, None)
+                                .await?;
+                            let inputs = clone_result(inputs_thunk.force().await)?;
+
+                            let resource = nixops4_resource::schema::v0::ExtantResource {
+                                input_properties: nixops4_resource::schema::v0::InputProperties(
+                                    inputs,
+                                ),
+                                output_properties: None,
+                                type_: nixops4_resource::schema::v0::ResourceType(
+                                    provider_info.resource_type.clone(),
+                                ),
+                            };
+
+                            (resource, provider_info)
                         }
                     };
 

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -1180,6 +1180,45 @@ impl WorkContext {
 
         let inputs = clone_result(inputs_thunk.force().await)?;
 
+        // Read past resource once and cache it for both the skip check and the
+        // later create-vs-update decision, avoiding a second state lock.
+        //
+        // Skip optimization: see "Skipping Unchanged Resources" in
+        // doc/manual/src/concept/resource.md for the assumptions.
+        let mut saved_past_resource: Option<crate::state::ResourceState> = None;
+        if let Some(ref state_handle) = state {
+            saved_past_resource = state_handle
+                .current
+                .lock()
+                .await
+                .deployment
+                .get_resource(&resource_path)
+                .cloned();
+            if let Some(ref past_resource) = saved_past_resource {
+                if past_resource.type_ != provider_info.resource_type {
+                    bail!(
+                        "Resource type change is not supported: {} != {}",
+                        past_resource.type_,
+                        provider_info.resource_type
+                    );
+                }
+                if inputs == past_resource.input_properties {
+                    tracing::info!(
+                        "Skipping update for resource {}: inputs unchanged",
+                        resource_path
+                    );
+                    return self
+                        .publish_resource_outputs(
+                            &resource_path,
+                            inputs,
+                            past_resource.output_properties.clone(),
+                            provider_info.resource_type,
+                        )
+                        .await;
+                }
+            }
+        }
+
         let span = info_span!(
             "creating resource",
             name = resource_path.to_string().as_str()
@@ -1209,22 +1248,10 @@ impl WorkContext {
                     format!("Failed to create stateless resource {}", resource_path)
                 })?,
             Some(ref state_handle) => {
-                let past_resource_opt = state_handle
-                    .current
-                    .lock()
-                    .await
-                    .deployment
-                    .get_resource(&resource_path)
-                    .cloned();
-                match past_resource_opt {
+                match saved_past_resource.take() {
                     Some(past_resource) => {
-                        if past_resource.type_ != provider_info.resource_type {
-                            bail!(
-                                "Resource type change is not supported: {} != {}",
-                                past_resource.type_,
-                                provider_info.resource_type
-                            );
-                        }
+                        // Type check already done above; inputs differ if we reach here
+                        tracing::debug!("Updating resource {}: inputs changed", resource_path);
                         let outputs = provider
                             .update(
                                 provider_info.resource_type.as_str(),

--- a/rust/nixops4/src/work.rs
+++ b/rust/nixops4/src/work.rs
@@ -38,38 +38,45 @@ pub enum PreviewItem {
     /// A resource that will be applied (full path from root)
     Resource(ComponentPath),
     /// A structural dependency that must be resolved before the full structure is known.
-    StructuralDependency {
-        /// The composite path where the unknown structure exists (if known)
-        path: Option<ComponentPath>,
-        /// The resource output this structure depends on
-        depends_on: NamedProperty,
-    },
+    StructuralDependency(StructuralDependency),
+}
+
+/// A dependency that occurs not merely between inputs and outputs of resources,
+/// but in the structure of the resource graph itself.
+///
+/// See https://nixops.dev/manual/development/concept/resource.html#structural-dependencies
+#[derive(Clone, Debug)]
+pub struct StructuralDependency {
+    /// The composite path where the unknown structure exists (if known).
+    pub path: Option<ComponentPath>,
+    /// The resource output this structure depends on.
+    pub depends_on: NamedProperty,
 }
 
 impl Display for PreviewItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PreviewItem::Resource(path) => write!(f, "{}", path),
-            PreviewItem::StructuralDependency { path, depends_on } => match path {
+            PreviewItem::StructuralDependency(dep) => match &dep.path {
                 Some(p) if p.is_root() => {
                     write!(
                         f,
                         "*  (structure depends on {}.{})",
-                        depends_on.resource, depends_on.name
+                        dep.depends_on.resource, dep.depends_on.name
                     )
                 }
                 Some(p) => {
                     write!(
                         f,
                         "{}.*  (depends on {}.{})",
-                        p, depends_on.resource, depends_on.name
+                        p, dep.depends_on.resource, dep.depends_on.name
                     )
                 }
                 None => {
                     write!(
                         f,
                         "*  (depends on {}.{})",
-                        depends_on.resource, depends_on.name
+                        dep.depends_on.resource, dep.depends_on.name
                     )
                 }
             },
@@ -195,11 +202,11 @@ pub enum Outcome {
     /// Preview result containing all known resources and structural dependencies
     Preview(Vec<PreviewItem>),
     /// Member names listed, or blocked by structural dependency (for preview)
-    MembersListed(Result<Vec<String>, PreviewItem>),
+    MembersListed(Result<Vec<String>, StructuralDependency>),
     /// An ID assigned to a member (from AssignMemberId)
     MemberIdAssigned(Id<AnyType>),
     /// A single member loaded, or blocked by structural dependency (for preview)
-    MemberLoaded(Result<ComponentHandle, PreviewItem>),
+    MemberLoaded(Result<ComponentHandle, StructuralDependency>),
     ResourceProviderInfo(eval_api::ResourceProviderInfo),
     ResourceInputsListed(Vec<String>),
     ResourceInputValue(Value),
@@ -254,7 +261,7 @@ impl WorkContext {
         composite_id: Id<CompositeType>,
         composite_path: &ComponentPath,
         mutation_cap: Option<MutationCapability>,
-    ) -> Result<Result<Vec<String>, PreviewItem>> {
+    ) -> Result<Result<Vec<String>, StructuralDependency>> {
         let r = context
             .require(Goal::ListMembers(
                 composite_id,
@@ -295,9 +302,10 @@ impl WorkContext {
             Outcome::MemberLoaded(Ok(handle)) => Ok(handle),
             Outcome::MemberLoaded(Err(dep)) => {
                 bail!(
-                    "Structural dependency while loading member '{}': {}",
+                    "Structural dependency while loading member '{}' (depends on {}.{})",
                     name,
-                    dep
+                    dep.depends_on.resource,
+                    dep.depends_on.name,
                 )
             }
             outcome => bail!("Unexpected outcome from LoadMember, {:?}", outcome),
@@ -318,7 +326,7 @@ impl WorkContext {
                 BTreeMap<String, Id<ResourceType>>,
                 BTreeMap<String, Id<CompositeType>>,
             ),
-            PreviewItem,
+            StructuralDependency,
         >,
     > {
         // Spawn all LoadMember goals in parallel
@@ -369,7 +377,7 @@ impl WorkContext {
                 BTreeMap<ComponentPath, Id<ResourceType>>,
                 BTreeMap<String, Id<CompositeType>>,
             ),
-            PreviewItem,
+            StructuralDependency,
         >,
     > {
         let names = match self
@@ -540,7 +548,7 @@ impl WorkContext {
         {
             Ok(partitioned) => partitioned,
             Err(structural_dep) => {
-                items.push(structural_dep);
+                items.push(PreviewItem::StructuralDependency(structural_dep));
                 // Can't continue if we don't know the structure
                 return Ok(Outcome::Preview(items));
             }
@@ -691,12 +699,10 @@ impl WorkContext {
                 StepResult::Needs(dep) => match mutation_cap {
                     Some(cap) => self.resolve_dependency(&context, &dep, Some(cap)).await?,
                     None => {
-                        return Ok(Outcome::MembersListed(Err(
-                            PreviewItem::StructuralDependency {
-                                path: Some(composite_path),
-                                depends_on: dep,
-                            },
-                        )));
+                        return Ok(Outcome::MembersListed(Err(StructuralDependency {
+                            path: Some(composite_path),
+                            depends_on: dep,
+                        })));
                     }
                 },
             }
@@ -795,12 +801,10 @@ impl WorkContext {
                 StepResult::Needs(dep) => match mutation_cap {
                     Some(cap) => self.resolve_dependency(&context, &dep, Some(cap)).await?,
                     None => {
-                        return Ok(Outcome::MemberLoaded(Err(
-                            PreviewItem::StructuralDependency {
-                                path: None,
-                                depends_on: dep,
-                            },
-                        )));
+                        return Ok(Outcome::MemberLoaded(Err(StructuralDependency {
+                            path: None,
+                            depends_on: dep,
+                        })));
                     }
                 },
             }

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -252,6 +252,34 @@ runCommand "itest-nixops4-with-local"
       rm nixops4-state.json.backup
     )
 
+    h2 "Test skip when inputs unchanged"
+    (
+      set -x
+      # Re-apply with unchanged inputs; the skip optimization should fire
+      nixops4 apply statefulDeployment --show-trace 2> skip-stderr.log
+      grep -qF "inputs unchanged" skip-stderr.log || {
+        echo "FAIL: expected 'inputs unchanged' in stderr"
+        cat skip-stderr.log
+        exit 1
+      }
+      mv skip-stderr.log $out/logs/skip-update.stderr
+    )
+
+    h2 "Test update when inputs changed"
+    (
+      set -x
+      # Change currentVersion back to 1 (it was set to 2 earlier)
+      sed -i 's/currentVersion = 2;/currentVersion = 1;/' flake.nix
+      # Re-apply with -v to capture debug output
+      nixops4 apply -v statefulDeployment --show-trace 2> update-stderr.log
+      grep -qF "inputs changed" update-stderr.log || {
+        echo "FAIL: expected 'inputs changed' in stderr"
+        cat update-stderr.log
+        exit 1
+      }
+      mv update-stderr.log $out/logs/update-inputs-changed.stderr
+    )
+
     (
       set -x
       # Clean up

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -98,6 +98,63 @@ runCommand "itest-nixops4-with-local"
 
       nix eval .#nixops4._type --show-trace
 
+      h1 NESTED MEMBERS LIST
+
+      h2 "Root (no arg): default is root, not a segment named '(root)'"
+      # Regression test: previously the clap default for `path` was
+      # `default_value_t = ComponentPath::root()`, which round-tripped through
+      # Display+FromStr and turned into a single-segment path `["(root)"]`,
+      # causing eval to look up a nonexistent `(root)` attribute.
+      nixops4 members list --show-trace > actual.txt
+      # The set of root members is large; assert at least one known one and
+      # that no line equals the literal '(root)'.
+      grep -qxF myDeployment actual.txt
+      ! grep -qxF '(root)' actual.txt
+      rm -f actual.txt
+
+      h2 "Single-level nesting: nestedDeployment.frontend"
+      nixops4 members list nestedDeployment.frontend --show-trace > actual.txt
+      printf '%s\n' assets staticVersion webConfig webVersion | sort > expected.txt
+      sort actual.txt > actual_sorted.txt
+      diff expected.txt actual_sorted.txt
+
+      h2 "Deeper nesting: nestedDeployment.frontend.assets"
+      nixops4 members list nestedDeployment.frontend.assets --show-trace > actual.txt
+      printf '%s\n' assetConfig assetVersion | sort > expected.txt
+      sort actual.txt > actual_sorted.txt
+      diff expected.txt actual_sorted.txt
+
+      h2 "Error case: nonexistent nested path"
+      (
+        set +e
+        nixops4 members list nestedDeployment.nonExistentPath --show-trace 2> err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "Failed to resolve path 'nestedDeployment.nonExistentPath'" err.log
+        grep "attribute.*nonExistentPath.*not found" err.log
+      )
+
+      mv err.log $out/logs/members-list-nonexistent.stderr
+
+      h2 "Error case: path resolves to resource not composite"
+      (
+        set +e
+        nixops4 members list statefulDeployment.state --show-trace 2> err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "Failed to resolve path 'statefulDeployment.state'" err.log
+        grep -F "Expected composite at statefulDeployment.state, but found resource" err.log
+      )
+
+      mv err.log $out/logs/members-list-resource-not-composite.stderr
+      rm -f actual.txt actual_sorted.txt expected.txt
+
       h1 BASIC STATELESS DEPLOYMENT
 
       nixops4 apply -v myDeployment --show-trace

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -691,6 +691,119 @@ runCommand "itest-nixops4-with-local"
       rm -f structural-cycle.stdout
     )
 
+    h1 STATE DUMP
+    (
+      set -x
+      echo "=== Testing state dump command ==="
+
+      # First apply statefulDeployment so state exists
+      nixops4 apply -v statefulDeployment --show-trace
+
+      h2 "Happy path: dump state of state-providing resource"
+      nixops4 state dump statefulDeployment.state --show-trace > state-dump.json
+      # Verify it's valid JSON with expected structure
+      jq -e '._type == "nixopsState"' state-dump.json
+      # Verify concrete resource value: initial_version memo should have value 1
+      # Resources are nested under deployments.statefulDeployment because the
+      # resource paths are stored relative to the root composite.
+      jq -e '.deployments.statefulDeployment.resources.initial_version.input_properties.initialize_with == 1' state-dump.json
+
+      h2 "Error: nonexistent path"
+      (
+        set +e
+        nixops4 state dump nonExistent.path --show-trace 2> state-dump-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "Failed to dump state stored in nonExistent.path" state-dump-err.log
+        grep "attribute.*nonExistent.*not found" state-dump-err.log
+      )
+
+      h2 "CLI help accuracy: argument mentions state-providing resource"
+      nixops4 state dump --help > state-dump-help.txt
+      grep -F "state-providing resource" state-dump-help.txt
+
+      h2 "Error: structural dependency blocks state dump"
+      (
+        set +e
+        nixops4 state dump structuralResourcesAttr.child.conditionalResource --show-trace 2> state-dump-structural-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        # Pin down the entire message so a refactor of the Err variant of
+        # MembersListed/MemberLoaded surfaces here as well as at the type site.
+        grep -Fx "nixops4 error: Cannot load 'structuralResourcesAttr.child.conditionalResource': blocked by structural dependency (depends on structuralResourcesAttr.selector.value)" state-dump-structural-err.log
+      )
+
+      mv state-dump-structural-err.log $out/logs/state-dump-structural-dependency.stderr
+
+      h2 "Error: path resolves to composite, not resource"
+      (
+        set +e
+        nixops4 state dump statefulDeployment --show-trace 2> state-dump-composite-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "is a composite (deployment), not an individual resource" state-dump-composite-err.log
+        grep -F "state-providing resource" state-dump-composite-err.log
+      )
+
+      mv state-dump-composite-err.log $out/logs/state-dump-composite-not-resource.stderr
+
+      h2 "Error: non-state resource"
+      (
+        set +e
+        nixops4 state dump statefulDeployment.initial_version --show-trace 2> state-dump-non-state-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "could not be read as a state provider" state-dump-non-state-err.log
+      )
+
+      h2 "Error: state dump when stateless dependency not created"
+      (
+        set +e
+        nixops4 state dump stateDumpDepStateless.state --show-trace 2> state-dump-dep-stateless-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "read-only mode" state-dump-dep-stateless-err.log
+        grep -F "stateDumpDepStateless.upstream.stdout" state-dump-dep-stateless-err.log
+      )
+
+      mv state-dump-dep-stateless-err.log $out/logs/state-dump-dep-stateless.stderr
+
+      h2 "Error: state dump when stateful dependency not created"
+      (
+        set +e
+        nixops4 state dump stateDumpDepStateful.state --show-trace 2> state-dump-dep-stateful-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "read-only mode" state-dump-dep-stateful-err.log
+        grep -F "stateDumpDepStateful.upstream.value" state-dump-dep-stateful-err.log
+      )
+
+      mv state-dump-dep-stateful-err.log $out/logs/state-dump-dep-stateful.stderr
+
+      # Clean up
+      mv state-dump-err.log $out/logs/state-dump-nonexistent.stderr
+      mv state-dump-non-state-err.log $out/logs/state-dump-non-state-resource.stderr
+      rm -f state-dump.json state-dump-help.txt nixops4-state.json
+    )
+
     h1 SUCCESS
     touch $out
   ''

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -57,6 +57,7 @@ runCommand "itest-nixops4-with-local"
     }
 
     h1 SETTING UP
+    mkdir -p $out/logs
 
     export HOME=$(mktemp -d $TMPDIR/home.XXXXXX)
     # configure a relocated store
@@ -119,6 +120,7 @@ runCommand "itest-nixops4-with-local"
 
       grep -F 'oh no, this and that failed' err.log
       grep -F 'Failed to create stateless resource failingDeployment.hello' err.log
+      mv err.log $out/logs/failing-deployment.stderr
     )
 
     h1 STATEFUL DEPLOYMENT
@@ -238,7 +240,8 @@ runCommand "itest-nixops4-with-local"
       rm -f listing-section.log
 
       # Clean up
-      rm -f unreferenced-nesting-state.json unreferenced-output.log
+      mv unreferenced-output.log $out/logs/unreferenced-nesting.stderr
+      rm -f unreferenced-nesting-state.json
     )
 
     h1 STRUCTURAL DEPENDENCY: CONDITIONAL COMPOSITES
@@ -261,7 +264,8 @@ runCommand "itest-nixops4-with-local"
       grep -E 'childResource.*child-value' structural-deployments.log
 
       # Clean up
-      rm -f structural-deployments-state.json structural-deployments.log
+      mv structural-deployments.log $out/logs/structural-deployments-attr.stderr
+      rm -f structural-deployments-state.json
     )
 
     h1 STRUCTURAL DEPENDENCY: CONDITIONAL RESOURCES IN COMPOSITE
@@ -283,7 +287,8 @@ runCommand "itest-nixops4-with-local"
       grep -E 'conditionalResource.*conditional-value' structural-resources.log
 
       # Clean up
-      rm -f structural-resources-state.json structural-resources.log
+      mv structural-resources.log $out/logs/structural-resources-attr.stderr
+      rm -f structural-resources-state.json
     )
 
     h1 DYNAMIC MEMBER KIND
@@ -307,7 +312,8 @@ runCommand "itest-nixops4-with-local"
       grep -E 'dynamicMember.*I am a resource' dynamic-kind.log
 
       # Clean up
-      rm -f dynamic-kind-state.json dynamic-kind.log
+      mv dynamic-kind.log $out/logs/dynamic-kind.stderr
+      rm -f dynamic-kind-state.json
     )
 
     h1 NESTED DEPLOYMENTS
@@ -415,7 +421,9 @@ runCommand "itest-nixops4-with-local"
       }
 
       # Clean up
-      rm -f nested-parent-state.json nested-output.log nested-output2.log
+      mv nested-output.log $out/logs/nested-deployment.stderr
+      mv nested-output2.log $out/logs/nested-deployment-update.stderr
+      rm -f nested-parent-state.json
     )
 
     h1 ERROR HANDLING: STATE POINTS TO COMPOSITE
@@ -443,7 +451,7 @@ runCommand "itest-nixops4-with-local"
       }
 
       # Clean up
-      rm -f state-composite-err.log
+      mv state-composite-err.log $out/logs/state-points-to-composite.stderr
     )
 
     h1 ERROR HANDLING: STATE POINTS TO NONEXISTENT MEMBER
@@ -471,7 +479,7 @@ runCommand "itest-nixops4-with-local"
       }
 
       # Clean up
-      rm -f state-nonexistent-err.log
+      mv state-nonexistent-err.log $out/logs/state-points-to-nonexistent.stderr
     )
 
     h1 ERROR HANDLING: STATE IN NONEXISTENT COMPOSITE
@@ -499,7 +507,7 @@ runCommand "itest-nixops4-with-local"
       }
 
       # Clean up
-      rm -f state-bad-path-err.log
+      mv state-bad-path-err.log $out/logs/state-in-nonexistent-composite.stderr
     )
 
     h1 ERROR HANDLING: CIRCULAR DEPENDENCY
@@ -553,7 +561,7 @@ runCommand "itest-nixops4-with-local"
       fi
 
       # Clean up
-      rm -f circular-err.log
+      mv circular-err.log $out/logs/circular-dependency.stderr
     )
 
     h1 ERROR HANDLING: STRUCTURAL DEPENDENCY CYCLE
@@ -584,7 +592,7 @@ runCommand "itest-nixops4-with-local"
       }
 
       # Clean up
-      rm -f structural-cycle-err.log
+      mv structural-cycle-err.log $out/logs/structural-cycle.stderr
     )
 
     h1 SUCCESS

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -98,6 +98,51 @@ runCommand "itest-nixops4-with-local"
 
       nix eval .#nixops4._type --show-trace
 
+      h1 NESTED MEMBERS LIST
+
+      h2 "Single-level nesting: nestedDeployment.frontend"
+      nixops4 members list nestedDeployment.frontend --show-trace > actual.txt
+      printf '%s\n' assets staticVersion webConfig webVersion | sort > expected.txt
+      sort actual.txt > actual_sorted.txt
+      diff expected.txt actual_sorted.txt
+
+      h2 "Deeper nesting: nestedDeployment.frontend.assets"
+      nixops4 members list nestedDeployment.frontend.assets --show-trace > actual.txt
+      printf '%s\n' assetConfig assetVersion | sort > expected.txt
+      sort actual.txt > actual_sorted.txt
+      diff expected.txt actual_sorted.txt
+
+      h2 "Error case: nonexistent nested path"
+      (
+        set +e
+        nixops4 members list nestedDeployment.nonExistentPath --show-trace 2> err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "Failed to resolve path 'nestedDeployment.nonExistentPath'" err.log
+        grep "attribute.*nonExistentPath.*not found" err.log
+      )
+
+      mv err.log $out/logs/members-list-nonexistent.stderr
+
+      h2 "Error case: path resolves to resource not composite"
+      (
+        set +e
+        nixops4 members list statefulDeployment.state --show-trace 2> err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "Failed to resolve path 'statefulDeployment.state'" err.log
+        grep -F "Expected composite at statefulDeployment.state, but found resource" err.log
+      )
+
+      mv err.log $out/logs/members-list-resource-not-composite.stderr
+      rm -f actual.txt actual_sorted.txt expected.txt
+
       h1 BASIC STATELESS DEPLOYMENT
 
       nixops4 apply -v myDeployment --show-trace

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -112,15 +112,16 @@ runCommand "itest-nixops4-with-local"
       set -x
       (
         set +e;
-        # 3>&1 etc: swap stderr and stdout
-        nixops4 apply -v failingDeployment --show-trace 3>&1 1>&2 2>&3 | tee err.log
+        nixops4 apply -v failingDeployment --show-trace > failing.stdout 2> failing.stderr
         [[ $? == 1 ]]
       )
+      [[ ! -s failing.stdout ]]
       [[ ! -e file.txt ]]
 
-      grep -F 'oh no, this and that failed' err.log
-      grep -F 'Failed to create stateless resource failingDeployment.hello' err.log
-      mv err.log $out/logs/failing-deployment.stderr
+      grep -F 'oh no, this and that failed' failing.stderr
+      grep -F 'Failed to create stateless resource failingDeployment.hello' failing.stderr
+      mv failing.stderr $out/logs/failing-deployment.stderr
+      rm -f failing.stdout
     )
 
     h1 STATEFUL DEPLOYMENT
@@ -207,21 +208,22 @@ runCommand "itest-nixops4-with-local"
 
       # Apply the deployment - the nested deployment has resources
       # that are not referenced by any parent resource
-      nixops4 apply -v unreferencedNesting --show-trace 2>&1 | tee unreferenced-output.log
+      nixops4 apply -v unreferencedNesting --show-trace > unreferenced.stdout 2> unreferenced.stderr
+      [[ ! -s unreferenced.stdout ]]
 
       # Verify state file was created
       test -f unreferenced-nesting-state.json
 
       # The parent resource should be applied
-      grep -E "parentResource.*parent-value" unreferenced-output.log
+      grep -E "parentResource.*parent-value" unreferenced.stderr
 
       # The nested deployment's orphanedResource should ALSO be applied
-      grep -E "orphanedResource.*orphan-value" unreferenced-output.log
+      grep -E "orphanedResource.*orphan-value" unreferenced.stderr
 
       # Verify that resources are listed BEFORE any are created
       # Get line numbers for key events
-      first_listing=$(grep -n "will be applied" unreferenced-output.log | head -1 | cut -d: -f1)
-      first_create=$(grep -n "creating resource" unreferenced-output.log | head -1 | cut -d: -f1)
+      first_listing=$(grep -n "will be applied" unreferenced.stderr | head -1 | cut -d: -f1)
+      first_create=$(grep -n "creating resource" unreferenced.stderr | head -1 | cut -d: -f1)
       echo "First listing at line $first_listing, first create at line $first_create"
       [[ $first_listing -lt $first_create ]] || {
         echo "ERROR: Resources should be listed before being created"
@@ -230,7 +232,7 @@ runCommand "itest-nixops4-with-local"
 
       # Verify that the orphan resource is listed in the "will be applied" section
       # Extract lines between first "will be applied" and first "creating resource"
-      sed -n "''${first_listing},''${first_create}p" unreferenced-output.log > listing-section.log
+      sed -n "''${first_listing},''${first_create}p" unreferenced.stderr > listing-section.log
       # In the unified model, the path is orphan/orphanedResource (nested composite member)
       grep -qE "orphan[./]orphanedResource|orphanedResource" listing-section.log || {
         echo "ERROR: orphan/orphanedResource should appear in the listing section before any resources are created"
@@ -240,8 +242,8 @@ runCommand "itest-nixops4-with-local"
       rm -f listing-section.log
 
       # Clean up
-      mv unreferenced-output.log $out/logs/unreferenced-nesting.stderr
-      rm -f unreferenced-nesting-state.json
+      mv unreferenced.stderr $out/logs/unreferenced-nesting.stderr
+      rm -f unreferenced.stdout unreferenced-nesting-state.json
     )
 
     h1 STRUCTURAL DEPENDENCY: CONDITIONAL COMPOSITES
@@ -252,20 +254,21 @@ runCommand "itest-nixops4-with-local"
       # This deployment has a conditional composite whose existence
       # depends on a resource output. ListMembers will detect a
       # structural dependency when determining which composites exist.
-      nixops4 apply -v structuralDeploymentsAttr --show-trace 2>&1 | tee structural-deployments.log
+      nixops4 apply -v structuralDeploymentsAttr --show-trace > structural-deployments.stdout 2> structural-deployments.stderr
+      [[ ! -s structural-deployments.stdout ]]
 
       # Verify state file was created
       test -f structural-deployments-state.json
 
       # The selector resource should be applied with value "enabled"
-      grep -E 'selector.*enabled' structural-deployments.log
+      grep -E 'selector.*enabled' structural-deployments.stderr
 
       # The conditionalChild composite's childResource should be applied
-      grep -E 'childResource.*child-value' structural-deployments.log
+      grep -E 'childResource.*child-value' structural-deployments.stderr
 
       # Clean up
-      mv structural-deployments.log $out/logs/structural-deployments-attr.stderr
-      rm -f structural-deployments-state.json
+      mv structural-deployments.stderr $out/logs/structural-deployments-attr.stderr
+      rm -f structural-deployments.stdout structural-deployments-state.json
     )
 
     h1 STRUCTURAL DEPENDENCY: CONDITIONAL RESOURCES IN COMPOSITE
@@ -275,20 +278,21 @@ runCommand "itest-nixops4-with-local"
 
       # This deployment has a nested composite whose resources
       # conditionally exist based on a parent resource output.
-      nixops4 apply -v structuralResourcesAttr --show-trace 2>&1 | tee structural-resources.log
+      nixops4 apply -v structuralResourcesAttr --show-trace > structural-resources.stdout 2> structural-resources.stderr
+      [[ ! -s structural-resources.stdout ]]
 
       # Verify state file was created
       test -f structural-resources-state.json
 
       # The selector resource should be applied with value "enabled"
-      grep -E 'selector.*enabled' structural-resources.log
+      grep -E 'selector.*enabled' structural-resources.stderr
 
       # The child's conditionalResource should be applied
-      grep -E 'conditionalResource.*conditional-value' structural-resources.log
+      grep -E 'conditionalResource.*conditional-value' structural-resources.stderr
 
       # Clean up
-      mv structural-resources.log $out/logs/structural-resources-attr.stderr
-      rm -f structural-resources-state.json
+      mv structural-resources.stderr $out/logs/structural-resources-attr.stderr
+      rm -f structural-resources.stdout structural-resources-state.json
     )
 
     h1 DYNAMIC MEMBER KIND
@@ -299,21 +303,22 @@ runCommand "itest-nixops4-with-local"
       # This deployment has a member whose KIND (resource vs composite)
       # depends on a resource output. LoadMember needs to resolve the
       # dependency to determine if it's loading a resource or composite.
-      nixops4 apply -v dynamicKind --show-trace 2>&1 | tee dynamic-kind.log
+      nixops4 apply -v dynamicKind --show-trace > dynamic-kind.stdout 2> dynamic-kind.stderr
+      [[ ! -s dynamic-kind.stdout ]]
 
       # Verify state file was created
       test -f dynamic-kind-state.json
 
       # The selector resource should be applied with value "resource"
-      grep -E 'selector.*resource' dynamic-kind.log
+      grep -E 'selector.*resource' dynamic-kind.stderr
 
       # Since selector outputs "resource", dynamicMember should be a resource
       # and contain "I am a resource"
-      grep -E 'dynamicMember.*I am a resource' dynamic-kind.log
+      grep -E 'dynamicMember.*I am a resource' dynamic-kind.stderr
 
       # Clean up
-      mv dynamic-kind.log $out/logs/dynamic-kind.stderr
-      rm -f dynamic-kind-state.json
+      mv dynamic-kind.stderr $out/logs/dynamic-kind.stderr
+      rm -f dynamic-kind.stdout dynamic-kind-state.json
     )
 
     h1 NESTED DEPLOYMENTS
@@ -329,33 +334,34 @@ runCommand "itest-nixops4-with-local"
       
       # Check that all memo resources have correct values
       # The deploymentSummary should contain all the versions
-      nixops4 apply -v nestedDeployment --show-trace 2>&1 | tee nested-output.log
-      
+      nixops4 apply -v nestedDeployment --show-trace > nested-output.stdout 2> nested-output.stderr
+      [[ ! -s nested-output.stdout ]]
+
       # Extract and verify values from the output
       # Parent resources
-      grep -E "parent.*v1\.0\.0" nested-output.log || echo "Parent version v1.0.0 expected"
-      grep -E "parent.*production" nested-output.log || echo "Parent config production expected"
-      
+      grep -E "parent.*v1\.0\.0" nested-output.stderr || echo "Parent version v1.0.0 expected"
+      grep -E "parent.*production" nested-output.stderr || echo "Parent config production expected"
+
       # Frontend resources
-      grep -E "frontend.*frontend-v1\.0\.0" nested-output.log || echo "Frontend version expected"
-      grep -E "web-production" nested-output.log || echo "Web config expected"
-      
-      # Backend resources  
-      grep -E "api-v1\.0\.0" nested-output.log || echo "API version expected"
-      grep -E "backend-production-frontend-frontend-v1\.0\.0" nested-output.log || echo "Backend config expected"
-      
+      grep -E "frontend.*frontend-v1\.0\.0" nested-output.stderr || echo "Frontend version expected"
+      grep -E "web-production" nested-output.stderr || echo "Web config expected"
+
+      # Backend resources
+      grep -E "api-v1\.0\.0" nested-output.stderr || echo "API version expected"
+      grep -E "backend-production-frontend-frontend-v1\.0\.0" nested-output.stderr || echo "Backend config expected"
+
       # Deeply nested resources
-      grep -E "assets-frontend-v1\.0\.0" nested-output.log || echo "Assets version expected"
-      grep -E "db-api-v1\.0\.0" nested-output.log || echo "Database version expected"
-      
+      grep -E "assets-frontend-v1\.0\.0" nested-output.stderr || echo "Assets version expected"
+      grep -E "db-api-v1\.0\.0" nested-output.stderr || echo "Database version expected"
+
       # The deployment summary should contain all values
-      grep -E "deploymentSummary.*parent:v1\.0\.0.*static:nested-static-v1.*frontend:frontend-v1\.0\.0.*backend:api-v1\.0\.0.*assets:assets-frontend-v1\.0\.0.*db:db-api-v1\.0\.0" nested-output.log || {
+      grep -E "deploymentSummary.*parent:v1\.0\.0.*static:nested-static-v1.*frontend:frontend-v1\.0\.0.*backend:api-v1\.0\.0.*assets:assets-frontend-v1\.0\.0.*db:db-api-v1\.0\.0" nested-output.stderr || {
         echo "ERROR: Deployment summary does not contain expected values"
         echo "Expected pattern: parent:v1.0.0|static:nested-static-v1|frontend:frontend-v1.0.0|backend:api-v1.0.0|assets:assets-frontend-v1.0.0|db:db-api-v1.0.0"
-        cat nested-output.log
+        cat nested-output.stderr
         exit 1
       }
-      
+
       echo "=== Testing state persistence in nested deployments ==="
 
       # Verify sed patterns exist before replacing (sanity check for test setup)
@@ -373,57 +379,58 @@ runCommand "itest-nixops4-with-local"
       sed -i 's/inputs.initialize_with = "nested-static-v1"/inputs.initialize_with = "nested-static-v2"/' flake.nix
 
       # Apply again
-      nixops4 apply -v nestedDeployment --show-trace 2>&1 | tee nested-output2.log
+      nixops4 apply -v nestedDeployment --show-trace > nested-output2.stdout 2> nested-output2.stderr
+      [[ ! -s nested-output2.stdout ]]
 
       # Parent version should remain v1.0.0 (memo preserves state)
-      grep -E "deploymentSummary.*parent:v1\.0\.0" nested-output2.log || {
+      grep -E "deploymentSummary.*parent:v1\.0\.0" nested-output2.stderr || {
         echo "ERROR: Parent version changed when it should have been preserved"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # Nested staticVersion should remain "nested-static-v1" despite input changing to v2
       # This directly tests that nested memo state is read back correctly
-      grep -E "deploymentSummary.*static:nested-static-v1" nested-output2.log || {
+      grep -E "deploymentSummary.*static:nested-static-v1" nested-output2.stderr || {
         echo "ERROR: Nested staticVersion changed when it should have been preserved"
         echo "This indicates nested memo state was not read back correctly"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # Nested resource state should also be preserved
       # frontend.webVersion should still be "frontend-v1.0.0"
-      grep -E "deploymentSummary.*frontend:frontend-v1\.0\.0" nested-output2.log || {
+      grep -E "deploymentSummary.*frontend:frontend-v1\.0\.0" nested-output2.stderr || {
         echo "ERROR: Nested frontend version changed when it should have been preserved"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # Deeply nested: frontend.assets.assetVersion should still be "assets-frontend-v1.0.0"
-      grep -E "deploymentSummary.*assets:assets-frontend-v1\.0\.0" nested-output2.log || {
+      grep -E "deploymentSummary.*assets:assets-frontend-v1\.0\.0" nested-output2.stderr || {
         echo "ERROR: Deeply nested assets version changed when it should have been preserved"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # backend.apiVersion should still be "api-v1.0.0"
-      grep -E "deploymentSummary.*backend:api-v1\.0\.0" nested-output2.log || {
+      grep -E "deploymentSummary.*backend:api-v1\.0\.0" nested-output2.stderr || {
         echo "ERROR: Nested backend version changed when it should have been preserved"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # Deeply nested: backend.database.dbVersion should still be "db-api-v1.0.0"
-      grep -E "deploymentSummary.*db:db-api-v1\.0\.0" nested-output2.log || {
+      grep -E "deploymentSummary.*db:db-api-v1\.0\.0" nested-output2.stderr || {
         echo "ERROR: Deeply nested database version changed when it should have been preserved"
-        cat nested-output2.log
+        cat nested-output2.stderr
         exit 1
       }
 
       # Clean up
-      mv nested-output.log $out/logs/nested-deployment.stderr
-      mv nested-output2.log $out/logs/nested-deployment-update.stderr
-      rm -f nested-parent-state.json
+      mv nested-output.stderr $out/logs/nested-deployment.stderr
+      mv nested-output2.stderr $out/logs/nested-deployment-update.stderr
+      rm -f nested-output.stdout nested-output2.stdout nested-parent-state.json
     )
 
     h1 ERROR HANDLING: STATE POINTS TO COMPOSITE
@@ -518,15 +525,16 @@ runCommand "itest-nixops4-with-local"
       # This deployment has resourceA depending on resourceB's output,
       # and resourceB depending on resourceA's output.
       # TaskTracker should detect the cycle.
-      # TODO: investigate why pipefail doesn't seem to be set; using PIPESTATUS as workaround
       (
         set +e
-        nixops4 apply circularDependency 2>&1 | grep -A100 "^nixops4 error:" > circular-err.log
-        exit_code=''${PIPESTATUS[0]}
+        nixops4 apply circularDependency > circular.stdout 2> circular.stderr
+        exit_code=$?
         [[ $exit_code != 0 ]] || {
           echo "ERROR: Expected apply to fail but it succeeded"
           exit 1
         }
+        [[ ! -s circular.stdout ]]
+        grep -A100 "^nixops4 error:" circular.stderr > circular-err.log
       )
 
       # Verify we get the exact cycle error message.
@@ -561,7 +569,8 @@ runCommand "itest-nixops4-with-local"
       fi
 
       # Clean up
-      mv circular-err.log $out/logs/circular-dependency.stderr
+      mv circular.stderr $out/logs/circular-dependency.stderr
+      rm -f circular.stdout circular-err.log
     )
 
     h1 ERROR HANDLING: STRUCTURAL DEPENDENCY CYCLE
@@ -576,23 +585,25 @@ runCommand "itest-nixops4-with-local"
       # The cycle is caught by Nix (not Rust) because the expression is recursive.
       (
         set +e
-        nixops4 apply structuralCycle 2>&1 | tee structural-cycle-err.log
-        exit_code=''${PIPESTATUS[0]}
+        nixops4 apply structuralCycle > structural-cycle.stdout 2> structural-cycle.stderr
+        exit_code=$?
         [[ $exit_code != 0 ]] || {
           echo "ERROR: Expected apply to fail but it succeeded"
           exit 1
         }
+        [[ ! -s structural-cycle.stdout ]]
       )
 
       # Verify we get an error (Nix-level recursion or evaluation error)
-      grep -qE "infinite recursion|Evaluation error|Cycle detected" structural-cycle-err.log || {
+      grep -qE "infinite recursion|Evaluation error|Cycle detected" structural-cycle.stderr || {
         echo "ERROR: Expected recursion/cycle/evaluation error"
-        cat structural-cycle-err.log
+        cat structural-cycle.stderr
         exit 1
       }
 
       # Clean up
-      mv structural-cycle-err.log $out/logs/structural-cycle.stderr
+      mv structural-cycle.stderr $out/logs/structural-cycle.stderr
+      rm -f structural-cycle.stdout
     )
 
     h1 SUCCESS

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -679,6 +679,87 @@ runCommand "itest-nixops4-with-local"
       rm -f structural-cycle.stdout
     )
 
+    h1 STATE DUMP
+    (
+      set -x
+      echo "=== Testing state dump command ==="
+
+      # First apply statefulDeployment so state exists
+      nixops4 apply -v statefulDeployment --show-trace
+
+      h2 "Happy path: dump state of state-providing resource"
+      nixops4 state dump statefulDeployment.state --show-trace > state-dump.json
+      # Verify it's valid JSON with expected structure
+      jq -e '._type == "nixopsState"' state-dump.json
+      # Verify concrete resource value: initial_version memo should have value 1
+      # Resources are nested under deployments.statefulDeployment because the
+      # resource paths are stored relative to the root composite.
+      jq -e '.deployments.statefulDeployment.resources.initial_version.input_properties.initialize_with == 1' state-dump.json
+
+      h2 "Error: nonexistent path"
+      (
+        set +e
+        nixops4 state dump nonExistent.path --show-trace 2> state-dump-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "nonExistent" state-dump-err.log
+      )
+
+      h2 "CLI help accuracy: argument mentions state-providing resource"
+      nixops4 state dump --help > state-dump-help.txt
+      grep -F "state-providing resource" state-dump-help.txt
+
+      h2 "Error: structural dependency blocks state dump"
+      (
+        set +e
+        nixops4 state dump structuralResourcesAttr.child.conditionalResource --show-trace 2> state-dump-structural-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "blocked by structural dependency" state-dump-structural-err.log
+      )
+
+      mv state-dump-structural-err.log $out/logs/state-dump-structural-dependency.stderr
+
+      h2 "Error: path resolves to composite, not resource"
+      (
+        set +e
+        nixops4 state dump statefulDeployment --show-trace 2> state-dump-composite-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "is a composite (deployment), not an individual resource" state-dump-composite-err.log
+        grep -F "state-providing resource" state-dump-composite-err.log
+      )
+
+      mv state-dump-composite-err.log $out/logs/state-dump-composite-not-resource.stderr
+
+      h2 "Error: non-state resource"
+      (
+        set +e
+        nixops4 state dump statefulDeployment.initial_version --show-trace 2> state-dump-non-state-err.log
+        exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          echo "FAIL: expected nonzero exit code" >&2
+          exit 1
+        fi
+        grep -F "could not be read as a state provider" state-dump-non-state-err.log
+      )
+
+      # Clean up
+      mv state-dump-err.log $out/logs/state-dump-nonexistent.stderr
+      mv state-dump-non-state-err.log $out/logs/state-dump-non-state-resource.stderr
+      rm -f state-dump.json state-dump-help.txt nixops4-state.json
+      rm -f initial-version.md current-version.md
+    )
+
     h1 SUCCESS
     touch $out
   ''

--- a/test/integration-test-nixops4-with-local/check.nix
+++ b/test/integration-test-nixops4-with-local/check.nix
@@ -240,6 +240,34 @@ runCommand "itest-nixops4-with-local"
       rm nixops4-state.json.backup
     )
 
+    h2 "Test skip when inputs unchanged"
+    (
+      set -x
+      # Re-apply with unchanged inputs; the skip optimization should fire
+      nixops4 apply statefulDeployment --show-trace 2> skip-stderr.log
+      grep -qF "inputs unchanged" skip-stderr.log || {
+        echo "FAIL: expected 'inputs unchanged' in stderr"
+        cat skip-stderr.log
+        exit 1
+      }
+      mv skip-stderr.log $out/logs/skip-update.stderr
+    )
+
+    h2 "Test update when inputs changed"
+    (
+      set -x
+      # Change currentVersion back to 1 (it was set to 2 earlier)
+      sed -i 's/currentVersion = 2;/currentVersion = 1;/' flake.nix
+      # Re-apply with -v to capture debug output
+      nixops4 apply -v statefulDeployment --show-trace 2> update-stderr.log
+      grep -qF "inputs changed" update-stderr.log || {
+        echo "FAIL: expected 'inputs changed' in stderr"
+        cat update-stderr.log
+        exit 1
+      }
+      mv update-stderr.log $out/logs/update-inputs-changed.stderr
+    )
+
     (
       set -x
       # Clean up

--- a/test/integration-test-nixops4-with-local/flake/flake.nix
+++ b/test/integration-test-nixops4-with-local/flake/flake.nix
@@ -121,6 +121,46 @@
                 };
               };
 
+            # For `state dump` read-only tests: the state provider's
+            # `name` input depends on another (uncreated) resource's output,
+            # so read-only dependency resolution has nothing in state to fall
+            # back to and must fail with a suitable error.
+            members.stateDumpDepStateless =
+              { members, ... }:
+              {
+                members.upstream = {
+                  type = providers.local.exec;
+                  inputs.executable = "hello";
+                  inputs.args = [
+                    "--greeting"
+                    "state-name-from-stateless"
+                  ];
+                };
+                members.state = {
+                  type = providers.local.state_file;
+                  inputs.name = members.upstream.outputs.stdout;
+                };
+              };
+
+            # As above, but the state provider depends on a stateful resource.
+            members.stateDumpDepStateful =
+              { members, ... }:
+              {
+                members.upstreamState = {
+                  type = providers.local.state_file;
+                  inputs.name = "upstream-state.json";
+                };
+                members.upstream = {
+                  type = providers.local.memo;
+                  state = members.upstreamState;
+                  inputs.initialize_with = "state-name-from-stateful.json";
+                };
+                members.state = {
+                  type = providers.local.state_file;
+                  inputs.name = members.upstream.outputs.value;
+                };
+              };
+
             # This is a comprehensive nested deployment test
             # It demonstrates resources with cross-deployment dependencies
             # and complex state management across multiple deployment levels

--- a/test/nixops4-resources-local.nix
+++ b/test/nixops4-resources-local.nix
@@ -90,6 +90,64 @@ runCommand "check-nixops4-resources-local"
 
     (set -x; jq -e '. == { "value": "hello world" }' memo_update.json)
 
+    # Test "exec" resource - update re-executes with new args
+
+    nixops4-resource-runner update \
+      --provider-exe nixops4-resources-local \
+      --type exec \
+      --inputs-json '{"executable": "hello", "args": ["--greeting", "updated greeting"], "once": false}' \
+      --previous-inputs-json '{"executable": "hello", "args": ["--greeting", "old greeting"], "once": false}' \
+      --previous-outputs-json '{"stdout": "old greeting\n"}' \
+      > exec_update.json
+    cat exec_update.json
+
+    (set -x; jq -e '. == { "stdout": "updated greeting\n" }' exec_update.json)
+
+    # Test "exec" resource - once=true create (stateful, executes normally)
+
+    nixops4-resource-runner create \
+      --provider-exe nixops4-resources-local \
+      --type exec \
+      --stateful \
+      --input-str executable 'hello' \
+      --input-json args '["--greeting", "once greeting"]' \
+      --input-json once 'true' \
+      > exec_once_create.json
+    cat exec_once_create.json
+
+    (set -x; jq -e '. == { "stdout": "once greeting\n" }' exec_once_create.json)
+
+    # Test "exec" resource - once=true update (preserves original output)
+
+    nixops4-resource-runner update \
+      --provider-exe nixops4-resources-local \
+      --type exec \
+      --inputs-json '{"executable": "hello", "args": ["--greeting", "new args"], "once": true}' \
+      --previous-inputs-json '{"executable": "hello", "args": ["--greeting", "once greeting"], "once": true}' \
+      --previous-outputs-json '{"stdout": "once greeting\n"}' \
+      > exec_once_update.json
+    cat exec_once_update.json
+
+    (set -x; jq -e '. == { "stdout": "once greeting\n" }' exec_once_update.json)
+
+    # Test "exec" resource - once=true WITHOUT stateful must fail
+
+    (
+      set +e
+      nixops4-resource-runner create \
+        --provider-exe nixops4-resources-local \
+        --type exec \
+        --input-str executable 'hello' \
+        --input-json args '[]' \
+        --input-json once 'true' \
+        > exec_once_stateless_out.json 2> exec_once_stateless_err.log
+      [[ $? == 1 ]]
+    )
+    # stdout should be empty (no JSON output on error)
+    [[ ! -s exec_once_stateless_out.json ]]
+    # stderr should contain the specific error
+    grep -F "exec resource with once=true requires state (use isStateful)" exec_once_stateless_err.log
+
     # Test that stateless resources bail on update
 
     (

--- a/test/nixops4-resources-local.nix
+++ b/test/nixops4-resources-local.nix
@@ -59,11 +59,11 @@ runCommand "check-nixops4-resources-local"
         --type exec \
         --input-str executable 'die' \
         --input-json args '["oh no, this and that failed"]' \
-        > out.json
+        > out.json 2> exec_exit_err.log
       [[ $? == 1 ]]
     )
-    cat out.json
-    [[ "" == "$(cat out.json)" ]]
+    [[ ! -s out.json ]]
+    grep -F "oh no, this and that failed" exec_exit_err.log
 
     # Test "memo" resource - create with state persistence
 
@@ -100,11 +100,11 @@ runCommand "check-nixops4-resources-local"
         --inputs-json '{"name": "/tmp/test", "contents": "new"}' \
         --previous-inputs-json '{"name": "/tmp/test", "contents": "old"}' \
         --previous-outputs-json '{}' \
-        > file_update_err.json 2>&1
+        > file_update_out.json 2> file_update_err.log
       [[ $? == 1 ]]
     )
-    cat file_update_err.json
-    grep -F "Internal error: update called on stateless file resource" file_update_err.json
+    [[ ! -s file_update_out.json ]]
+    grep -F "Internal error: update called on stateless file resource" file_update_err.log
 
     # Test that memo resource bails when created statelessly
 
@@ -114,11 +114,11 @@ runCommand "check-nixops4-resources-local"
         --provider-exe nixops4-resources-local \
         --type memo \
         --input-json initialize_with '"test value"' \
-        2>&1 | tee memo_stateless_err.json
+        > memo_stateless_out.json 2> memo_stateless_err.log
       [[ $? == 1 ]]
     )
-    cat memo_stateless_err.json
-    grep -F "memo resources require state (isStateful must be true)" memo_stateless_err.json
+    [[ ! -s memo_stateless_out.json ]]
+    grep -F "memo resources require state (isStateful must be true)" memo_stateless_err.log
 
     # Test "state_file" resource - create new state file
 
@@ -282,9 +282,11 @@ runCommand "check-nixops4-resources-local"
         --provider-exe nixops4-resources-local \
         --type state_file \
         --input-str name "invalid-state.json" \
-        2>&1 | tee state_invalid_err.json
+        > state_invalid_out.json 2> state_invalid_err.log
       [[ $? == 1 ]]
     )
+    [[ ! -s state_invalid_out.json ]]
+    grep -F "State file invalid" state_invalid_err.log
 
     echo "All state persistence tests passed!"
 


### PR DESCRIPTION
- Add a `once` parameter to the `exec` resource for one-time side-effecting initializations (e.g. UUID generation, or *unencrypted* keys *for the daring*)
- Generalize `members list` from root-only to wherever it's not output-dependent
- Some fixes

## Context

- Elaborating non-tfproto changes from their prototype in #150